### PR TITLE
Correct Kinvolk developer affiliation

### DIFF
--- a/cncf-config/domain-map
+++ b/cncf-config/domain-map
@@ -351,7 +351,7 @@ kddi.com KDDI
 kddilabs.jp KDDI
 kent.ac.uk University of Kent
 keyspan.com InnoSys
-kinvolk.io CoreOS
+kinvolk.io Kinvolk
 kionetworks.com KIO Networks
 kontron.com Kontron
 kt.com KT Corporation

--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -223,8 +223,8 @@ Alan Jones: watercraftsoftware!gmail.com
 	Nimble Storage until 2015-10-15
 Alan Williams: alanwill81!gmail.com
 	Google
-Alban Crequy: alban!kinvolk.io
-	CoreOS
+Alban Crequy: alban!kinvolk.io, alban.crequy!gmail.com
+	Kinvolk
 Albert Vaca: albertvaka!gmail.com
 	Verse Technologies
 Albert Zhang: zhgwenming!gmail.com
@@ -1004,8 +1004,8 @@ Chris Kim: christopherjkim!gmail.com
 Chris Knowles: c-knowles!users.noreply.github.com, chris.knowles!bitgamelabs.com
 	Bitgame Labs
 	Omnifone until 2015-11-15
-Chris Kühl: chris!kinvolk.io
-	CoreOS
+Chris Kühl: chris!kinvolk.io, blixtra!gmail.com
+	Kinvolk
 Chris Love: clove!cnmconsulting.net
 	CNM Consulting
 Chris Machler: chris.machler!evergreenitco.com
@@ -1897,8 +1897,8 @@ Hunter Nield: hunternield!gmail.com
 	Morphlabs
 Hyunchel Kim: hyunchel!fashionmetric.com
 	Bold Metrics
-Iago López Galeiras: iago!kinvolk.io
-	CoreOS
+Iago López Galeiras: iago!kinvolk.io, iaguis!gmail.com, iaguis!users.noreply.github.com
+	Kinvolk
 Iain Cambridge: iain!humblyarrogant.io
 	NotFound
 Ian Beringer: ian!ianberinger.com
@@ -3278,7 +3278,7 @@ Michal Gebauer: mishak!mishak.net
 Michal Minar: miminar!redhat.com
 	Red Hat
 Michal Rostecki: michal!kinvolk.io, mrostecki!mirantis.com
-	CoreOS
+	Kinvolk
 	Mirantis until 2016-11-30
 	Self until 2015-08-19
 	Allegro until 2015-08-07
@@ -4012,7 +4012,7 @@ Robert Deusser: iamthemuffinman!outlook.com
 	Roche until 2016-01-15
 	The AME Group until 2014-05-15
 Robert Günzler: robertguenzler!kinvolk.io
-	CoreOS
+	Kinvolk
 Robert Jefe Lindstaedt: robert.lindstaedt!gmail.com
 	Self
 Robert Kozikowski: r.kozikowski!gmail.com


### PR DESCRIPTION
While we at Kinvolk have a good relationship with the fine folks at CoreOS and have worked with them in the past, Kinvolk is not CoreOS, nor do its engineers work at CoreOS.

I think the root cause of this is the domain mapping. But I've also gone through and fixed the `developers_affiliations.txt` file.