### PR TITLE
Fix up jbeda affiliation

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -4596,7 +4596,7 @@ Jason DeWitt: me!roxet.net
 	Sudo Pseience
 Jason Derrett: jason!librato.com
 	Librato
-Jason Dillaman*: dillaman!redhat.com 
+Jason Dillaman*: dillaman!redhat.com
 	Red Hat
 	Red Hat
 Jason Dillaman*: dillamana!redhat.com, jdillama!redhat.com, jdillaman!redhat.com
@@ -4972,7 +4972,7 @@ Jodie Putrino: j.putrino!f5.com
 	F5 Networks
 Joe Beda: joe!bedafamily.com, joe!heptio.com, joe.github!bedafamily.com
 	Heptio
-	Red Hat until 2016-12-01
+	Google until 2015-01-01
 Joe Betz: jpbetz!google.com
 	Google
 Joe Black: joeblackwaslike!me.com


### PR DESCRIPTION
Looks like some trailing whitespace got caught up with this too.  Hopefully that isn't a problem.

Signed-off-by: Joe Beda <joe.github@bedafamily.com>