### PR TITLE
Update VMware Dev Affiliations

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -376,6 +376,8 @@ Akshay Dixit: akshaydixi!gmail.com
 	Tower Research Capital
 Akshay Karle: akshay.a.karle!gmail.com
 	ThoughtWorks
+Akshay Luther: akshay.luther!gmail.com,aluther!vmware.com
+	VMware
 Akshay Mankar: amankar!pivotal.io
 	Pivotal
 Akshay Shah: akshayjshah!users.noreply.github.com
@@ -462,6 +464,8 @@ Alex Elder*: elder!dreamhost.com
 	DreamHost
 Alex Elder*: elder!inktank.com
 	Inktank
+Alex Ellis: alex!openfaas.com, alexellis!vmware.com
+	VMware
 Alex Gaynor: alex.gaynor!gmail.com
 	Rackspace
 Alex Hornung: alex!alexhornung.com
@@ -685,7 +689,7 @@ Alon Lavi: alon!argus-sec.com, alonl!users.noreply.github.com
 	Argus Cyber Security
 Alon Pe'er: alon.peer!soundcloud.com
 	SoundCloud
-Alton Fong: altonf!vmware.com
+Alton Fong: altonf!vmware.com, altonfong!gmail.com
 	VMware
 Alvaro Lopez Ortega: alvaro!gnu.org
 	Akamai Technologies
@@ -830,6 +834,8 @@ Andrew Kreiling: akreiling!homeaway.com
 	HomeAway.com
 Andrew Kroh: andrew.kroh!elastic.co
 	Elastic
+Andrew Kutz: akutz!vmware.com
+	VMware from 2018-03-10
 Andrew Lau: andrew!andrewklau.com
 	andrewklau
 Andrew Lee Rubinger: alr!alrubinger.com
@@ -1317,6 +1323,8 @@ Ben Breslauer: bbreslauer!google.com
 	Google
 Ben Corlett: ben.corlett!gmail.com
 	BSkyB
+Ben Corrie: bcorrie!vmware.com
+	VMware
 Ben Dang: me!bdang.it
 	bdang.it
 	General Dynamics Mission System until 2017-05-17
@@ -2213,8 +2221,10 @@ Cliff Burdick: 30670611+cliffburdick!users.noreply.github.com
 	ViaSat
 Clint Checketts: clint.checketts!domo.com
 	Domo
-Clint Kitson: clintonskitson!gmail.com
-	EMC
+Clint Kitson: clintonskitson!gmail.com, clinton.kitson!emc.com, clinton.kitson!dell.com, ckitson!vmware.com
+	EMC until 2018-03-09
+	Dell until 2018-03-09
+	VMware from 2018-03-10
 Clive Cox: cc!seldon.io
 	Seldon
 CoderAway28th: CoderAway28th!users.noreply.github.com
@@ -2812,8 +2822,9 @@ David Zafman*: dzafman!redhat.com
 	Red Hat
 David Zhu: dyzz!google.com
 	Google
-David vonThenen: 12752197+dvonthenen!users.noreply.github.com, david.vonthenen!dell.com
-	Dell
+David vonThenen: 12752197+dvonthenen!users.noreply.github.com, david.vonthenen!dell.com, vonthenend!vmware.com
+	Dell until 2018-03-09
+	VMware from 2018-03-10
 DavidObando: DavidObando!users.noreply.github.com
 	Microsoft
 Davide Agnello: dagnello!hp.com, davide_agnello!hotmail.com, davideagnello!gmail.com
@@ -3062,7 +3073,7 @@ Doug Davis: dug!us.ibm.com, duglin!users.noreply.github.com
 	IBM
 Doug Koch: doug!dougkoch.me
 	NotFound
-Doug MacEachern: dougm!vmware.com
+Doug MacEachern: dougm!vmware.com, dmaceachern!vmware.com
 	VMware
 Douglas Fuller: dfuller!redhat.com
 	Red Hat
@@ -3461,7 +3472,7 @@ Fabio Kung*: fabio!heroku.com
 	Heroku
 Fabio Kung*: fabio.kung!gmail.com
 	Caelum
-Fabio Rapposelli: fabio!vmware.com
+Fabio Rapposelli: fabio!vmware.com, fabio!rapposelli.org
 	VMware
 Fabio Yeon: fabioy!fabioy-macbookpro2.roam.corp.google.com, fabioy!google.com, fabioy!users.noreply.github.com
 	Google
@@ -4365,8 +4376,9 @@ Ivan Kiselev: i.kiselev!2gis.ru
 	2GIS
 Ivan Kozlovic: ivan.kozlovic!apcera.com
 	Apcera
-Ivan Mikushin: i.mikushin!gmail.com
-	Rancher
+Ivan Mikushin: i.mikushin!gmail.com, imikushin!vmware.com
+	Rancher until 2017-07-31
+	VMware from 2017-08-11
 Ivan Pedrazas: ipedrazas!gmail.com
 	kube.camp
 Ivan Senic: ivan.senic!novatec-gmbh.de
@@ -4634,7 +4646,7 @@ Jason DeWitt: me!roxet.net
 	Sudo Pseience
 Jason Derrett: jason!librato.com
 	Librato
-Jason Dillaman*: dillaman!redhat.com 
+Jason Dillaman*: dillaman!redhat.com
 	Red Hat
 	Red Hat
 Jason Dillaman*: dillamana!redhat.com, jdillama!redhat.com, jdillaman!redhat.com
@@ -6290,7 +6302,7 @@ Lourens Naudé: lourens.naude!shopify.com
 	Shopify
 Loïc Frering: loic.frering!gmail.com
 	Atos WorldlineWorldline Global
-Lubomir I. Ivanov: lubomirivanov!vmware.com
+Lubomir I. Ivanov: lubomirivanov!vmware.com, neolit123!gmail.com
 	VMware
 Luc Perkins: lucperkins!gmail.com
 	Streamlio
@@ -6645,6 +6657,8 @@ Mark Gibaud: mark.gibaud!justgiving.com
 	JustGiving
 Mark Janssen: mark!praseodym.net
 	Independent
+Mark Johnson: markj!vmware.com
+	VMware
 Mark Joseph Ronquillo: markronquillo23!gmail.com
 	NotFound
 Mark Kampe: mark.kampe!dreamhost.com
@@ -6689,6 +6703,8 @@ Mark Snelling: mark!bakedbeans.com
 	Solaise Capital Management
 Mark St.Godard: markstgodard!gmail.com
 	IBM
+Mark Sterin: msterin!vmware.com
+	VMware
 Mark deVilliers: markdevilliers!gmail.com
 	Thingful
 Marko Bonaći: mbonaci!users.noreply.github.com
@@ -7206,6 +7222,8 @@ Michael Hudson-Doyle: michael.hudson!canonical.com
 	Canonical
 Michael Jeffrey: mjeffrey!mjeffrey-macpro.kir.corp.google.com
 	Google
+Michael K: michael-k!users.noreply.github.com
+	VMware
 Michael Kibbe: kibbles-n-bytes!users.noreply.github.com, mkibbe!google.com, mkibbe1993!users.noreply.github.com
 	Google
 Michael Laccetti: michael!laccetti.com
@@ -7873,6 +7891,8 @@ Niels-Ole Kühl: niels-ole.kuehl!flixbus.com
 	FlixBus
 Nigel Charman: nigel.charman.nz!gmail.com
 	Assurity
+Nikhil Deshpande: ndeshpande!vmware.com
+	VMware
 Nikhil Manchanda: slicknik!gmail.com
 	HPE
 	HP until 2015-10-31
@@ -8527,6 +8547,8 @@ Praseetha KR: praseetha04!gmail.com
 	Appknox
 Prashant Varanasi: github!prashantv.com
 	Uber
+Prashant Dhamdhere: pdhamdhere!vmware.com
+	VMware
 Prateek Agarwal: prat0318!gmail.com
 	Yelp
 Prateek Pandey: prateekpandey14!gmail.com
@@ -9289,6 +9311,8 @@ Saksham Sharma: saksham0808!gmail.com, sakshams!google.com
 	Google
 Salvatore Dario Minonne: salvatore-dario.minonne!amadeus.com
 	Amadeus
+Salvatore Orlando: sorlando!vmware.com
+	VMware
 Sam: sammcj!users.noreply.github.com
 	Infoxchange
 Sam Abed*: samabed!gmail.com
@@ -9452,6 +9476,8 @@ Scott Devoid: devoid!anl.gov
 	Argonne National Laboratory
 Scott Dodson: sdodson!redhat.com
 	Red Hat
+Scott Feldstein: sfeldstein!vmware.com
+	VMware
 Scott Fleckenstein: nullstyle!gmail.com
 	Stellar Development Foundation
 Scott Konzem: konzems!gmail.com
@@ -10091,6 +10117,9 @@ Steve Wilkerson: wilkers.steve!gmail.com
 	AT&T
 Steve Winslow: swinslow!gmail.com
 	Linux
+Steve Wong: steven.wong!dell.com, wongsteven!vmware.com
+	Dell until 2018-03-09
+	VMware from 2018-03-10
 Steve-Fontes: Steve-Fontes!users.noreply.github.com
 	IBM
 Steve53: Steve53!users.noreply.github.com
@@ -10742,8 +10771,10 @@ Travis Nielsen*: tnielsen!redhat.com
 	Red Hat
 Travis Nielsen*: travis.nielsen!quantum.com, travisn!live.com
 	Quantum
-Travis Rhoden: trhoden!redhat.com
-	Red Hat
+Travis Rhoden: trhoden!redhat.com, trhoden!dell.com, trhoden!vmware.com
+	Red Hat until 2015-10-31
+	Dell until 2018-03-09
+	VMware from 2018-03-10
 Travis Thompson: trthomps!confluent.io
 	Confluent
 	SAP until 2017-05-15
@@ -10794,6 +10825,8 @@ Tupin Laurent: ltupin!users.noreply.github.com
 	Amysta
 Tushar Gohad: tushar.gohad!intel.com
 	Intel
+Tushar Thole: tthole!vmware.com
+	VMware
 Tycho Andersen: tycho!docker.com
 	Docker
 Tyler Brekke: tbrekke!redhat.com
@@ -10885,6 +10918,8 @@ Vaughn Dice: vadice!microsoft.com, vaughn!deis.com
 	Microsoft
 Ved-vampir: akiselyova!mirantis.com
 	Mirantis
+Venil Noronha: venil.noronha!outlook.com, noronha!vmware.com
+	VMware
 Venkata Subbarao Chunduri: venkat!quobyte.com
 	Quobyte
 Venky Shankar: vshankar!redhat.com
@@ -11063,8 +11098,9 @@ Vladimir Rutsky*: rutsky!users.noreply.github.com, rutsky.vladimir!gmail.com, vl
 	Buildbot
 Vladimir Shcherbakov: shcherbakov.mailbox!gmail.com
 	Microsoft
-Vladimir Vivien: vladimir.vivien!gmail.com, vladimirvivien!users.noreply.github.com
-	Dell
+Vladimir Vivien: vladimir.vivien!gmail.com, vladimirvivien!users.noreply.github.com, vivienv!vmware.com
+	Dell until 2018-03-09
+	VMware from 2018-03-10
 Vojtech Vitek: vojtech.vitek!gmail.com, vojtech.vitek!pressly.com
 	Pressly
 Vojtech Vitek (V-Teq): vvitek!redhat.com
@@ -11217,6 +11253,8 @@ William Douglas: william.douglas!intel.com
 	Intel
 William Kennedy: bill!ardanstudios.com
 	Ardan Studios
+William Lam: lamw!users.noreply.github.com, wlam!vmware.com, lamw!vmware.com, info.virtuallyghetto!gmail.com
+	VMware
 William Markito: markito!users.noreply.github.com
 	Red Hat
 William Martin Stewart: zoidbergwill!gmail.com
@@ -18932,8 +18970,6 @@ laly_liu: laly_liu!163.com
 	H3C
 lambert_sun: lambert_sun!trendmicro.com.cn
 	Trend Micro
-lamw: lamw!users.noreply.github.com
-	VMware
 lana.brindley: lana.brindley!rackspace.com
 	Rackspace
 lance.bragstad: lance.bragstad!rackspace.com


### PR DESCRIPTION
This patch updates the file `developer_affiliations.txt` to reflect the most recent data for VMware contributors. The information was gathered by using [akutz/github-impact](https://github.com/akutz/github-impact) in combination with [gharchive.org](http://gharchive.org) and [Google's BigQuery](https://cloud.google.com/bigquery/).

cc @clintkitson