### PR TITLE
Rework SUSE/Novell list

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -436,7 +436,7 @@ Aleks Saul: aleks.saul!coreos.com, aleks.saul!gmail.com
 	Red Hat
 	VMware until 2016-03-15
 Aleksa Sarai: asarai!suse.com, asarai!suse.de
-	SUSE/Novell
+	SUSE
 Aleksandr Didenko: adidenko!mirantis.com
 	Mirantis
 Aleksandra Malinowska: aleksandram!google.com
@@ -1275,7 +1275,7 @@ Austin Vance and Tim Labeeuw: pair+austin+tim!pivotallabs.com
 Author xiao-zhou: xxiaozhou!gmail.com
 	Independent
 AvengerMoJo: AvengerMoJo!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 Avesh: avesh.ncsu!gmail.com
 	Red Hat
 Avesh Agarwal: avagarwa!redhat.com
@@ -1553,7 +1553,7 @@ Blaine Gardner*: blaine.gardner!hp.com
 Blaine Gardner*: blaine.gardner!suse.com
 	SUSE
 BlaineEXE: BlaineEXE!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 Blair Kutzman: bkutzman!google.com
 	Google
 Blake Haggerty: blake.haggerty!rackspace.com
@@ -3612,7 +3612,7 @@ Federico Padua: federico_padua!yahoo.it
 Federico Simoncelli: fsimonce!redhat.com
 	Red Hat
 FedericoCeratto: FedericoCeratto!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 Felipe Cavalcanti: fjfcavalcanti!gmail.com
 	topfreegames
 Felipe Musse: felipe.musse!sap.com
@@ -4159,7 +4159,7 @@ Harshal Patil: harshal.patil!in.ibm.com
 Harshavardhana: fharshav!redhat.com
 	Red Hat
 HartS: HartS!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 Harvey Tuch: htuch!google.com
 	Google
 Hasanat Kazmi: hasanatkazmi!gmail.com
@@ -4722,7 +4722,7 @@ Jan Chaloupka: jchaloup!redhat.com
 Jan Dolecek: juzna.cz!gmail.com
 	eDigitalResearch
 Jan Fajerski: jfajerski!suse.com
-	SUSE/Novell
+	SUSE
 Jan Jungnickel: jan!jungnickel.com
 	SGM-Media
 Jan Matejek: jmatejek!suse.com
@@ -7493,7 +7493,7 @@ Michal Fojtik: mfojtik!redhat.com
 	Red Hat
 Michal Gebauer: mishak!mishak.net
 	Internet Mall, a.s.
-Michal Jura: mjura!suse.com
+Michal Jura: mjura!suse.com, mjura!users.noreply.github.com
 	SUSE
 Michal Koutný: mkoutny!suse.com
 	SUSE
@@ -7918,7 +7918,7 @@ Nathan Button: nathan.button!gmail.com, nbutton!ancestry.com
 Nathan Cutler*: nculter!suse.com
 	SUSE
 Nathan Cutler*: ncutler!suse.com, ncutler!suse.cz, presnypreklad!gmail.com
-	SUSE/Novell
+	SUSE
 Nathan Herring: nherring!google.com
 	Google
 Nathan LeClaire: nathanleclaire!gmail.com
@@ -8271,7 +8271,7 @@ Ovidiu Predescu: ovidiu!gmail.com
 Owen Barton: github!owenbarton.com
 	Independent
 Owen Synge: osynge!suse.com
-	SUSE/Novell
+	SUSE
 Oz N Tiram: oz.tiram!mobilityhouse.com
 	The Mobility House GmbH
 	Plan-Net GmbH until 2016-08-15
@@ -9048,7 +9048,7 @@ Ri Xu: xuri.me!gmail.com
 Ric (Ryszard) Szopa: ryszard.szopa!gmail.com
 	Google
 Ricardo Dias: rdias!suse.com
-	SUSE/Novell
+	SUSE
 Ricardo Katz: rikatz!users.noreply.github.com
 	SERPRO
 Ricardo Lourenco: rlourenc!redhat.com
@@ -10243,7 +10243,7 @@ Stefan Gangefors: gangefors!users.noreply.github.com, stefan!gangefors.com
 Stefan Junker: code!stefanjunker.de, mail!stefanjunker.de, steveej!users.noreply.github.com
 	Red Hat
 Stefan Knorr: sknorr!suse.de
-	SUSE/Novell
+	SUSE
 Stefan Martinov: stefan.martinov!gmail.com
 	bestbytes
 Stefan Saasen: ssaasen!atlassian.com
@@ -10454,7 +10454,7 @@ Suraj Narwade: surajnarwade!users.noreply.github.com, surajnarwade353!gmail.com
 Suramya Shah: ss22ever!users.noreply.github.com
 	Independent
 Sushil Kumar: sushil.kumar!suse.com
-	SUSE/Novell
+	SUSE
 Suyog Barve: suyogbarve!gmail.com
 	Walmart
 Sven Dowideit: svendowideit!home.org.au
@@ -12160,7 +12160,7 @@ abmusic: abmusic!cisco.com
 abogott: abogott!wikimedia.org
 	Wikimedia Foundation
 abonillasuse: abonillasuse!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 abramley: abramley!bram-mac.local
 	Tesora
 aburdenthehand: aburden!redhat.com
@@ -13979,13 +13979,13 @@ cdent: cdent!mirantis.com
 	Mirantis
 	Red Hat until 2015-11-13
 cduch: cduch!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 ced5: ced5!users.noreply.github.com
 	Google
 cedric lamoriniere: cedric.lamoriniere!amadeus.com
 	Amadeus
 cedric.bosdonnat: cedric.bosdonnat!free.fr
-	SUSE/Novell
+	SUSE
 cedric.brandily: cedric.brandily!thalesgroup.com
 	Thales
 cedric.savignan: cedric.savignan!orange.com
@@ -15955,7 +15955,7 @@ erabug: erabug!users.noreply.github.com
 erakorn: erakorn!outlook.com
 	AT&T
 ereslibre: ereslibre!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 eric: eric!cloudscaling.com
 	Docker
 	Cloudscaling until 2014-01-03
@@ -17538,7 +17538,7 @@ indicoliteplus: indicoliteplus!gmail.com
 indradhanush: indradhanush!users.noreply.github.com
 	Kinvolk
 inercia: inercia!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 inferno-chromium: inferno-chromium!users.noreply.github.com
 	Google
 info: info!bitergia.com
@@ -20830,8 +20830,6 @@ mjsteger: mjsteger!users.noreply.github.com
 	GoodGuide
 mjudeikis: mjudeikis!users.noreply.github.com
 	Red Hat
-mjura: mjura!users.noreply.github.com
-	SUSE/Novell
 mkaliyam: mkaliyam!redhat.com
 	Red Hat
 	eNovance until 2014-06-24
@@ -20926,7 +20924,7 @@ mnestratov: mnestratov!virtuozzo.com
 mnewby: mnewby!internap.com
 	Red Hat
 mnowaksuse: mnowaksuse!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 mnussbaum: mnussbaum!users.noreply.github.com
 	Braintree
 moander: morten!vianett.no
@@ -24036,7 +24034,7 @@ stefanprodan: stefanprodan!users.noreply.github.com
 stefanstranger: stefanstranger!users.noreply.github.com
 	Microsoft
 stefsuse: stefsuse!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 stelfer: stelfer!cray.com
 	StackHPC
 	Cray until 2015-08-14
@@ -24681,7 +24679,7 @@ tnakaike: tnakaike!users.noreply.github.com
 tnapierala: tnapierala!mirantis.com
 	Mirantis
 toabctl: toabctl!users.noreply.github.com
-	SUSE/Novell
+	SUSE
 tobad357: tobias.adamson!gmail.com
 	The Manufacturing Institute
 tobilarscheid: tobilarscheid!gmail.com


### PR DESCRIPTION
There's no Novell anymore, move all known SUSE folks with
SUSE/Novell affiliation to SUSE only.