### PR TITLE
fix attribution for Rafael Chacon

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -9063,8 +9063,8 @@ Rafael Barreto: rafael!thebackplane.com
 	Backplane.io
 Rafael Benevides: benevides!redhat.com
 	Red Hat
-Rafael Chacón: rafaelchacon!gmail.com
-	MyFitnessPal
+Rafael Chacón: rafaelchacon!gmail.com, rafael!slack-corp.com
+	Slack
 Rafael Chicoli: rafael_chicoli!regis24.de, rafaelchicoli!hotmail.com
 	NotFound
 Rafael Franzke: rafael.franzke!sap.com


### PR DESCRIPTION
Fix attribution to indicate that Rafael Chacon works for Slack .
