### PR TITLE
Update developer affiliation for Andy Goldstein

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -1038,10 +1038,9 @@ Andy Chou: acchou2!gmail.com
 	Stealth
 Andy Diamondstein: adiamondstein!adiamondstein-macbookpro.roam.corp.google.com, adiamondstein!google.com
 	Google
-Andy Goldstein*: agoldste!redhat.com
-	Red Hat
-Andy Goldstein*: andy.goldstein!gmail.com
-	ASG Consulting
+Andy Goldstein: andy.goldstein!gmail.com, andy!heptio.com, agoldste!redhat.com
+	Heptio
+	Red Hat until 2017-06-02
 Andy Hume: andyhume!gmail.com
 	Brandwatch
 Andy Lindeman*: andy!lindeman.io
@@ -3789,7 +3788,7 @@ Felix Abecassis: fabecassis!nvidia.com
 	NVidia
 Felix Becker: felix.b!outlook.com
 	Sourcegraph
-Felix Bünemann: buenemann!louis.info
+Felix Bünemann: buenemann!louis.info
 	LOUISINTERNET
 Felix Rodriguez: felix.a.rod!gmail.com
 	Vungle
@@ -10803,7 +10802,7 @@ Stevo Slavic: sslavic!gmail.com
 	SAP
 Stewart-YU: 30410021+stewart-yu!users.noreply.github.com
 	Huawei
-Stéphane Klein: contact!stephane-klein.info
+Stéphane Klein: contact!stephane-klein.info
 	TechAngels
 Stig Telfer: stig.github!telfer.org, stig.openstack!telfer.org
 	StackHPC
@@ -11370,7 +11369,7 @@ Tomasz Napierala: tomasz!napierala.org
 	Mirantis
 Tomasz Prus: tomasz.prus!gmail.com
 	Ocado Technology
-Tomasz Wojtuń: wojtut01!stepstone.com
+Tomasz Wojtuń: wojtut01!stepstone.com
 	StepStone
 Tomek Kulczynski: tkulczynski!google.com
 	Google


### PR DESCRIPTION
I'm not sure why the accented characters in other people's names are getting changed by this patch. I initially edited it directly in GitHub and it did this. Then I reverted the non-relevant lines in vim and recommitted but they're still showing up in the diff. Please let me know if that's a problem and if you can advise how to fix. Thanks!

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>