### PR TITLE
Solly Ross --> Google

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -14692,8 +14692,9 @@ Soham Sinha: soham.m17!gmail.com
 	Ericsson until 2014-06-01
 Soheil Hassas Yeganeh: soheil!cs.toronto.edu, soheil!google.com
 	Google
-Solly Ross: directxman12+github!gmail.com, sross!redhat.com
-	Red Hat
+Solly Ross: directxman12+github!gmail.com, sollyross!google.com, sross!redhat.com
+	Google
+    Red Hat until 2018-10-06
 Solomon Duskis: sduskis!google.com
 	Google
 Solomon Hykes: solomon!docker.com


### PR DESCRIPTION
Move Solly Ross to be affiliated with Google (instead of Red Hat).