### PR TITLE
Update affiliation for shomron (again)

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -12143,7 +12143,7 @@ Oren Duer: oren!mellanox.com
 Oren Held: orenhe!il.ibm.com
 	IBM
 Oren Shomron: shomron!gmail.com
-	Oracle
+	Heptio
 Orit Wasserman: owasserm!redhat.com, owassern!redhat.com, owassrm!redhat.com
 	Red Hat
 Orkhan Mamedov: orkhanm!users.noreply.github.com


### PR DESCRIPTION
@lukaszgryglicki I'm not sure why, but my previous affiliation change (4a589f292bfdc1950e86b2740e6511d658542880) was reverted in 3d8e55faea8b312e4918fc265fed1691375ec5dd.

Do you know what might be wrong?
Thanks!

Signed-off-by: Oren Shomron <shomron@gmail.com>