### PR TITLE
Follow previous gitdm convention of having Heptio commits belong to VMware

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -897,7 +897,6 @@ Alexander Block: ablock84!gmail.com
 	Independent
 Alexander Brand: abrand!apprenda.com, alexbrand09!gmail.com
 	VMware
-	Heptio until 2018-12-11
 	Apprenda until 2018-01-14
 Alexander Brandstedt*: alexander!infralium.com, alexander.brandstedt!ea.com, alexanderbrandstedt!gmail.com, mad01!users.noreply.github.com
 	Spotify
@@ -1685,7 +1684,6 @@ Andy Diamondstein: adiamondstein!adiamondstein-macbookpro.roam.corp.google.com, 
 	Google
 Andy Goldstein: agoldste!redhat.com, andy.goldstein!gmail.com
 	VMware
-	Heptio until 2018-12-11
 	Red Hat until 2017-06-02
 Andy Hume: andyhume!gmail.com
 	Brandwatch
@@ -3330,7 +3328,6 @@ Carles Lopez: litus81!gmail.com
 	Nexica until 2014-08-15
 Carlisia: carlisia!grokkingtech.io
 	VMware
-	Heptio until 2018-12-11
 	Fastly until 2018-06-01
 	Verve until 2016-07-01
 	LivingSocial until 2015-02-01
@@ -4058,7 +4055,7 @@ Chuanhong Wang: wang.chuanhong!zte.com.cn
 Chuanjian Wang: me!ckeyer.net
 	Sina
 Chuck Ha*: chuck!heptio.com, ha.chuck!gmail.com
-	Heptio
+	VMware
 	Etsy until 2017-06-01
 Chuck Ha*: chuckh!vmware.com
 	VMware
@@ -5836,7 +5833,6 @@ Ducas Francis: ducas!ducasfrancis.com
 	Readify until 2015-07-01
 Duffie Cooley: dcooley!heptio.com, duffie.cooley!coreos.com
 	VMware
-	Heptio until 2018-12-11
 	CoreOS until 2018-03-15
 Duncan McNaught: duncan.mcnaught!welltok.com
 	Welltok
@@ -7605,7 +7601,6 @@ Harshvardhan Karn: harshvkarn54!gmail.com
 	Independent until 2018-01-01
 Hart Hoover: hart!heptio.com
 	VMware
-	Heptio until 2018-12-11
 HartS: HartS!users.noreply.github.com
 	SUSE
 Harvey Tuch: htuch!google.com
@@ -8709,7 +8704,6 @@ Jason Buberel: jason!buberel.org
 	Altos Research
 Jason DeTiberus: detiber!gmail.com, detiberusj!vmware.com, jason!heptio.com
 	VMware
-	Heptio until 2018-12-11
 	Red Hat until 2018-01-29
 Jason DeWitt: me!roxet.net
 	Sudo Pseience
@@ -9392,9 +9386,10 @@ Jochen Breuer: jbreuer!suse.de
 	SUSE
 Jodie Putrino: j.putrino!f5.com
 	F5Networks
-Joe Beda: joe!bedafamily.com, joe!heptio.com, joe.github!bedafamily.com
-	VMware
-	Heptio until 2018-12-11
+Joe Beda*: jbeda!vmware.com, joe!bedafamily.com
+    VMware
+	Google until 2016-12-01
+Joe Beda*: joe!heptio.com, joe.github!bedafamily.com
 	CoreOS until 2016-11-01
 	Google until 2015-01-01
 Joe Betz: jpbetz!google.com
@@ -9914,9 +9909,8 @@ Jorge Luis Middleton: jorge.middleton!gmail.com
 	Accenture
 Jorge Marin: jorge!bitnami.com
 	Bitnami
-Jorge O. Castro: jorge!heptio.com, jorge!ubuntu.com, jorge.castro!gmail.com
-	VMware
-	Heptio until 2018-12-11
+Jorge O. Castro: jorgec!vmware.com, jorge!heptio.com, jorge!ubuntu.com, jorge.castro!gmail.com
+    VMware
 	Canonical until 2017-03-31
 Jorge Salamero Sanz: bencer!users.noreply.github.com
 	Sysdig
@@ -10065,7 +10059,6 @@ Josh Zamor: josh.zamor!villagereach.org
 	VillageReach
 JoshRosso: JoshRosso!users.noreply.github.com
 	VMware
-	Heptio until 2018-11-01
 	Red Hat until 2018-04-01
 	MuleSoft until 2016-10-01
 Joshua Barratt: jbarratt!serialized.net
@@ -11046,14 +11039,12 @@ Kris: krousey!google.com
 	Google
 Kris Budde: kris.budde!gmail.com
 	SkyCom
-Kris Dockery: kris!heptio.com
-	VMware
-	Heptio until 2018-12-11
+Kris Dockery: dockeryk!vmware.com, kris!heptio.com
+    VMware
 Kris Kowal: kris!cixar.com
 	Uber
-Kris Nova: kris!nivenly.com
-	VMware
-	Heptio until 2018-12-11
+Kris Nova: novan!vmware.com, kris!nivenly.com
+    VMware
 Krishna Pagadala: rkrishnap!google.com
 	Google
 	Independent until 2017-01-01
@@ -12789,9 +12780,8 @@ Matt Moore: mattmoor!google.com
 	Google
 Matt Moore (via sockpuppet): mattmoor+sockpuppet!google.com
 	Google
-Matt Moyer: moyer!heptio.com
-	VMware
-	Heptio until 2018-12-11
+Matt Moyer: moyerm!vmware.com, moyer!heptio.com
+    VMware
 Matt Nickles: matt!elasticbox.com
 	ElasticBox
 Matt Palmer: mpalmer!hezmatt.org
@@ -13988,9 +13978,8 @@ NAVEEN NAHATA: naveen.nahata!blrmcb-78469.local
 	NotFound
 NIkhil Bhatia: nbhatia!microsoft.com
 	Microsoft
-Naadir Jeewa: naadir!randomvariable.co.uk
-	VMware
-	Heptio until 2018-12-11
+Naadir Jeewa: jeewan!vmware.com, naadir!randomvariable.co.uk
+    VMware
 	The Scale Factory until 2017-11-13
 	uSwith until 2015-07-01
 Nader Ziada: nziada!pivotal.io
@@ -14685,9 +14674,8 @@ Oren Duer: oren!mellanox.com
 	Mellanox
 Oren Held: orenhe!il.ibm.com
 	IBM
-Oren Shomron: shomron!gmail.com
-	VMware
-	Heptio until 2018-12-11
+Oren Shomron: shomrono!vmware.com, shomron!gmail.com
+    VMware
 Orit Wasserman: owasserm!redhat.com, owassern!redhat.com, owassrm!redhat.com
 	Red Hat
 Orkhan Mamedov: orkhanm!users.noreply.github.com
@@ -16518,9 +16506,8 @@ Ross Guarino: rssguar!gmail.com
 	CloudFlare
 	EnerNOC until 2016-05-15
 	NTID DAS until 2016-01-15
-Ross Kukulinski: ross!kukulinski.com
-	VMware
-	Heptio until 2018-12-11
+Ross Kukulinski: kukulinskiro!vmware.com, ross!kukulinski.com
+    VMware
 Ross Light: light!google.com
 	Google
 Ross McIlroy: rmcilroy!google.com
@@ -16550,9 +16537,8 @@ Ruben Kerkhof: ruben!rubenkerkhof.com
 	Tilla
 Ruben Oanta: roanta!twitter.com
 	Twitter
-Ruben Orduz: rubenoz!gmail.com
-	VMware
-	Heptio until 2018-12-11
+Ruben Orduz: orduzr!vmware.com, rubenoz!gmail.com
+    VMware
 	IBM Blue BOX until 2017-03-01
 	Infor until 2015-11-01
 	Rackspace until 2015-02-01
@@ -18209,9 +18195,8 @@ Steve Sharp: stevenson.sharp!gmail.com
 	Independent until 2018-03-01
 	Apigee until 2016-12-01
 	Independent until 2014-05-01
-Steve Sloka: slokas!upmc.edu, steve!stevesloka.com, steves!heptio.com
-	VMware
-	Heptio until 2018-12-11
+Steve Sloka: slokas!vmware.com, slokas!upmc.edu, steve!stevesloka.com, steves!heptio.com
+    VMware
 Steve Stodola: sstodola!plytro.com
 	Shutterstock
 Steve Taylor: steve!deployhub.com
@@ -18593,9 +18578,8 @@ Tamas Berghammer: tberghammer!google.com
 	Google
 Tamer Tas: contact!tmrts.com, tamertas!outlook.com, tmrts!users.noreply.github.com
 	Independent
-TamikoT: TamikoT!users.noreply.github.com
-	VMware
-	Heptio until 2018-12-11
+TamikoT: teradat!vmware.com, TamikoT!users.noreply.github.com
+    VMware
 Tamil Muthamizhan*: tamil!inktank.com
 	Inktank
 Tamil Muthamizhan*: tamil!magna002.ceph.redhat.com
@@ -19066,7 +19050,6 @@ Timothy Perrett: timothy!getintheloop.eu
 	Intel until 2014-02-01
 Timothy St. Clair: timothysc!gmail.com, timothysc!users.noreply.github.com, tstclair!redhat.com
 	VMware
-	Heptio until 2018-12-11
 	Red Hat until 2017-02-15
 Timur Khafizov: timurkhafizov!users.noreply.github.com
 	GitHub
@@ -19802,7 +19785,7 @@ Vimal Raghubir: vraghubir0418!gmail.com
 Vince Montalbano: vince.montalbano!gmail.com
 	iHeart Media
 Vince Prignano*: vince!vincepri.com
-	Heptio
+	VMware
 Vince Prignano*: vincepri!vmware.com
 	VMware
 Vincent: github!fleeto.us
@@ -21287,7 +21270,6 @@ abramley: abramley!bram-mac.local
 	Tesora
 abrand: abrand!heptio.com
 	VMware
-	Heptio until 2018-12-11
 	Apprenda until 2018-01-14
 abrennan89: abrennan89!users.noreply.github.com
 	Red Hat
@@ -21780,7 +21762,6 @@ alexandre.lecuyer: alexandre.lecuyer!corp.ovh.com
 	OVH
 alexb: alexb!heptio.com
 	VMware
-	Heptio until 2018-12-11
 	Apprenda until 2018-01-14
 alexblyzn: alexblyzn!users.noreply.github.com
 	Google
@@ -22180,7 +22161,7 @@ andy: andy!andybotting.com
 andy: andy!edmonds.be
 	Independent
 andy: andy!heptio.com
-	Heptio
+	VMware
 	Red Hat until 2017-06-02
 andy.edmonds: andy.edmonds!gmail.com
 	Independent
@@ -23260,7 +23241,6 @@ bran-wang: branw!vmware.com
 	VMware
 branda: branda!vmware.com
 	VMware
-	Heptio until 2018-12-11
 	Apprenda until 2018-01-14
 brandonbodnar-wk: brandonbodnar-wk!users.noreply.github.com
 	Workiva
@@ -24382,7 +24362,6 @@ contato: contato!stenioelson.com.br
 	Independent
 cooleyd: cooleyd!vmware.com
 	VMware
-	Heptio until 2018-12-11
 	CoreOS until 2018-03-15
 coolias.lj: coolias.lj!gmail.com
 	t2cloud
@@ -25163,7 +25142,6 @@ destijl: destijl!users.noreply.github.com
 	Google
 detiber: detiber!users.noreply.github.com
 	VMware
-	Heptio until 2018-12-11
 	Red Hat until 2018-01-29
 deustis: deustis!users.noreply.github.com
 	Google
@@ -27794,7 +27772,6 @@ hhktony: hhktony!gmail.com
 	t2cloud
 hhoover: hart.hoover!gmail.com
 	VMware
-	Heptio until 2018-12-11
 hhovsepy: hhovsepy!users.noreply.github.com
 	Red Hat
 hi5san: hi5san!users.noreply.github.com
@@ -27875,7 +27852,6 @@ hongzhili: hongzhili!users.noreply.github.com
 	Microsoft
 hooverh: hooverh!vmware.com
 	VMware
-	Heptio until 2018-12-11
 hotchkj: hotchkj!users.noreply.github.com
 	Autodesk
 hotsuka: hotsuka!mirantis.com
@@ -29717,7 +29693,6 @@ joshng: joshng!users.noreply.github.com
 	SalesForce
 joshrosso: joshrosso!gmail.com
 	VMware
-	Heptio until 2018-11-01
 	Red Hat until 2018-04-01
 	MuleSoft until 2016-10-01
 joshua: joshua!pistoncloud.com
@@ -31074,7 +31049,6 @@ linsun: linsun!users.noreply.github.com
 	IBM
 linux: linux!mauilion.com
 	VMware
-	Heptio until 2018-12-11
 	CoreOS until 2018-03-15
 linxuhua: linxuhua!unionpay.com
 	China UnionPay
@@ -32852,7 +32826,6 @@ monty.taylor: monty.taylor!hp.com
 	Rackspace until 2011-11-20
 moondev: chad.d.moon!gmail.com
 	VMware
-	Heptio until 2019-01-01
 	Independent until 2018-10-01
 	Apple until 2018-08-02
 	Kenzan until 2018-08-01

--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -1682,7 +1682,7 @@ Andy Curtis: arcurtis!gmail.com
 	Avi Networks until 2015-10-01
 Andy Diamondstein: adiamondstein!adiamondstein-macbookpro.roam.corp.google.com, adiamondstein!google.com
 	Google
-Andy Goldstein: agoldste!redhat.com, andy.goldstein!gmail.com
+Andy Goldstein: goldsteina!vmware.com, agoldste!redhat.com, andy.goldstein!gmail.com
 	VMware
 	Red Hat until 2017-06-02
 Andy Hume: andyhume!gmail.com
@@ -9387,7 +9387,7 @@ Jochen Breuer: jbreuer!suse.de
 Jodie Putrino: j.putrino!f5.com
 	F5Networks
 Joe Beda*: jbeda!vmware.com, joe!bedafamily.com
-    VMware
+	VMware
 	Google until 2016-12-01
 Joe Beda*: joe!heptio.com, joe.github!bedafamily.com
 	CoreOS until 2016-11-01
@@ -9910,7 +9910,7 @@ Jorge Luis Middleton: jorge.middleton!gmail.com
 Jorge Marin: jorge!bitnami.com
 	Bitnami
 Jorge O. Castro: jorgec!vmware.com, jorge!heptio.com, jorge!ubuntu.com, jorge.castro!gmail.com
-    VMware
+	VMware
 	Canonical until 2017-03-31
 Jorge Salamero Sanz: bencer!users.noreply.github.com
 	Sysdig
@@ -13980,8 +13980,8 @@ NIkhil Bhatia: nbhatia!microsoft.com
 	Microsoft
 Naadir Jeewa: jeewan!vmware.com, naadir!randomvariable.co.uk
     VMware
-	The Scale Factory until 2017-11-13
-	uSwith until 2015-07-01
+	The Scale Factory until 2018-11-13
+	uSwitch until 2015-07-01
 Nader Ziada: nziada!pivotal.io
 	Pivotal
 Nadja Deininger: nadja!ef.gy
@@ -27167,10 +27167,6 @@ gokhan.isik: gokhan.isik!tubitak.gov.tr
 	TUBITAK
 gokulpch: gokulpch!users.noreply.github.com
 	Juniper Networks
-goldsteina: goldsteina!vmware.com
-	VMware
-	Heptio until 2018-12-11
-	Red Hat until 2017-06-02
 goltermann: goltermann!google.com, goltermann!users.noreply.github.com
 	Google
 golvteppe: bjoern.erik.strand!gmail.com


### PR DESCRIPTION
There are a few exceptions like people who left prior to this, I am
leaving those untouched for now. 

