### PR TITLE
Fix affiliations for Scale Factory contributors

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -10472,6 +10472,8 @@ Dominik Klein: dominik.klein!linux.ibm.com
 Dominik Sandjaja: dominik!dadadom.de, dominik.sandjaja!trivago.com
 	Trivago
 	IT-motiveAG until 2016-07-01
+Dominik Zyla: dom!scalefactory.com, sfzylad!users.noreply.github.com
+	The Scale Factory
 Dominik Schulz: dominik.schulz!gauner.org, dominik.schulz!gmail.com, dominik.schulz!justwatch.com
 	JustWatch
 Dominik Vogt: vogt!linux.vnet.ibm.com

--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -37046,6 +37046,8 @@ Tim Allclair: tallclair!google.com
 	Google
 Tim Anderson: tanderson!mvista.com
 	MontaVista
+Tim Bannister: tim!scalefactory.com, sftim!users.noreply.github.com
+	The Scale Factory
 Tim Bielawa: tbielawa!redhat.com
 	Red Hat
 Tim Bingham: tbingham!akamai.com

--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -9417,7 +9417,7 @@ David Newswanger: gamma.dave!gmail.com
 David O'Riordan: doriordan!gmail.com
 	Capgemini
 David O'Rourke: david!scalefactory.com
-	State Farm
+	The Scale Factory
 David Ogutu: davidogutu!gmail.com
 	Google
 David Oostdyk: daveo!ll.mit.edu

--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -4869,7 +4869,7 @@ Benjamin Pineau: ben.pineau!gmail.com, bpineau!users.noreply.github.com
 	Bilendi Technology until 2014-09-01
 Benjamin Poirier: bpoirier!suse.com, bpoirier!suse.de
 	SUSE
-Benjamin Priestman: benjamin!miniverse.me.uk
+Benjamin Priestman: ben!scalefactory.com, benjamin!miniverse.me.uk
 	The Scale Factory
 	Immediate Media until 2018-03-01
 Benjamin Romer: benjamin.romer!unisys.com


### PR DESCRIPTION
- correct wrong affiliation for David O'Rourke
- add Tim Bannister
- add Dom Zyla
- add Scale Factory email address for Ben Priestman

all 4 are employees at [The Scale Factory](https://www.scalefactory.com/).