### PR TITLE
Affiliate Siddharth Bhadri Gmail-ID to huawei

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -7635,7 +7635,7 @@ Sibiao Luo: sluo!redhat.com
 	Red Hat
 Siddarth Gore: gores!marvell.com
 	Marvell
-Siddharth Bhadri: siddharth.bhadri!huawei.com
+Siddharth Bhadri: siddharth.bhadri!huawei.com, bhadri.siddharth!gmail.com
 	Huawei
 Siddharth Rakesh: sidrakesh!google.com
 	Google


### PR DESCRIPTION
Affiliate Siddharth Bhadri Gmail-ID to huawei