### PR TITLE
Update Affiliation to Hitachi

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -30443,7 +30443,7 @@ Masakazu Mokuno: masakazu.mokuno!jp.sony.com, mokuno!sm.sony.co.jp
 	Sony
 Masakazu Urade: urade.masakazu!jp.panasonic.com
 	Panasonic
-Masaki Kimura: masaki.kimura.kz!hitachi.com
+Masaki Kimura: masaki.kimura.kz!hitachi.com, masaki.kimura!hitachivantara.com
 	Hitachi
 Masaki Matsushita: glass.saga!gmail.com
 	NTT
@@ -33358,9 +33358,7 @@ Mitsuhiro Kimura: mitsuhiro.kimura.kc!renesas.com
 	Renesas Technology
 Mitsuhiro Tanda: mitsuhiro.tanda!gmail.com
 	GREE
-Mitsuhiro Tanino*: mitsuhiro.tanino!hds.com
-	Hitachi Data Systems
-Mitsuhiro Tanino*: mitsuhiro.tanino.gm!hitachi.com
+Mitsuhiro Tanino: mitsuhiro.tanino!hds.com, mitsuhiro.tanino.gm!hitachi.com, mitsuhiro.tanino!hitachivantara.com
 	Hitachi
 Mitsunori Komatsu: komamitsu!gmail.com
 	Treasure Data


### PR DESCRIPTION
This PR corrects affiliation to Hitachi.

Some Hitachi members have commited from multiple e-mail domains, such as hitachi.com, hds.com, and hitachivantara.com, but they all should be regarded as Hitachi. Therefore, this PR fixes as such.