### PR TITLE
Update affiliation for @srueg

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -8983,8 +8983,9 @@ Simon Pasquier*: spasquier!mirantis.com
 	Bull until 2014-06-30
 Simon Que: sque!ti.com
 	Texas Instruments
-Simon Rüegg: simon!rueggs.ch
-	Ruf Telematik AG
+Simon Rüegg: simon.ruegg!vshn.ch
+	VSHN
+	Ruf Telematik AG until 2017-07-31
 Simon Sandström: simon!nikanor.nu
 	Tieto
 	Independent until 2015-01-01


### PR DESCRIPTION
Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>