### PR TITLE
Separate my work and independent contributions

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -29046,6 +29046,7 @@ Lucas Kannebley Tavares: lucaskt!linux.vnet.ibm.com
 	IBM
 Lucas Käldström: lucas!weave.works, lucas.kaldstrom!hotmail.co.uk, luxas!users.noreply.github.com
 	Weaveworks
+	Independent until 2016-12-20
 Lucas Langer: lucaslanger!twitter.com
 	Twitter
 	Independent until 2016-01-01


### PR DESCRIPTION
I'm working for Weaveworks, and using my lucas@weave.works email for work on their behalf.
However, some contributions I do outside of work, and for these I use my personal hotmail address.

Is this the right way of separating these types of contributions?
Is there any tool in this repo that could show how many contributions are tracked on these email addresses respectively (in DevStats)?

cc @lukaszgryglicki @monadic