### PR TITLE
fix: Fix Ce Gao's affiliation

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -8648,9 +8648,7 @@ Cathy Luo: cluo!marvell.com
 	Marvell
 Cathy Zhou: cathy.zhou!oracle.com
 	Oracle
-Ce Gao*: ce.gao!outlook.com
-	TouchPal
-Ce Gao*: gaoce!caicloud.io
+Ce Gao: gaoce!caicloud.io, ce.gao!outlook.com, gaocegege!hotmail.com
 	Caicloud
 Ce Gu: guce_baresi!163.com
 	NetEase


### PR DESCRIPTION
Hi, I think this is a mistake here. The two mails are owned by me and I am a Caicloud employee. 

BTW, do I need to update src/cncf-config/email-map or github-user.json?