### PR TITLE
Remove duplicate entries for Angus Salkeld

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4305,11 +4305,7 @@ Angus Lees: gus!inodes.org
 	Bitnami
 	Rackspace until 2016-10-01
 	Google until 2014-03-01
-Angus Salkeld*: angus.salkeld!rackspace.com, asalkeld!redhat.com
-	Mirantis
-	Rackspace until 2014-08-15
-	Red Hat until 2014-01-03
-Angus Salkeld*: asalkeld!mirantis.com
+Angus Salkeld*: asalkeld!mirantis.com, angus.salkeld!rackspace.com, asalkeld!redhat.com
 	Red Hat
 	TechnologyOne until 2018-09-01
 	Mirantis until 2016-11-01


### PR DESCRIPTION
Currently my profile says

Full Name: Angus Salkeld
Groups: CNCF - Mirantis Inc.

It should say "Red Hat", it could be because of the duplicate entries here and also because I used to work for Red Hat before 2014 as well. I hope this fixes my affiliations.