### PR TITLE
fix Kevin Wang (@kevin-wangzefeng)'s affiliation

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -28221,6 +28221,8 @@ Kevin VanMaren: kvanmaren!lnxi.com
 	Linux Networx
 Kevin W Monroe: kevin.monroe!canonical.com
 	Canonical
+Kevin Wang*: wangzefeng@huawei.com, kevinwzf0126@gmail.com
+	Huawei
 Kevin Wang*: kevin1.wang!amd.com, kevink1.wang!amd.com
 	AMD
 Kevin Wang*: kevin807359!gmail.com


### PR DESCRIPTION
In kubeedge.devstats.cncf.io my activities were counted to a wrong company.
Hope this PR helps.

P.S.
![image](https://user-images.githubusercontent.com/6914660/62059229-66501780-b255-11e9-93ac-9c6c038e4b03.png)

Ref: https://kubeedge.devstats.cncf.io/d/56/company-commits-table?orgId=1&from=now-1y&to=now&var-repogroups=All&var-companies=Del%20SecureWorks