### PR TITLE
Update affiliations for users who moved from FreshTracks to Splunk

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -5226,7 +5226,8 @@ Bob Callaway: bob.callaway!netapp.com
 Bob Cao: bobintornado!gmail.com
 	Tinkerbox
 Bob Cotton: bcotton!users.noreply.github.com, bob.cotton!gmail.com
-	FreshTracks
+	Splunk
+	FreshTracks until 2018-11-01
 	Independent until 2017-01-01
 Bob Killen: rkillen!umich.edu
 	Independent
@@ -6905,8 +6906,9 @@ Chris Machler: chris.machler!evergreenitco.com
 Chris Mair: chrismair!earthlink.net
 	Earthlink
 Chris Marchbanks: csmarchbanks!gmail.com, csmarchbanks!users.noreply.github.com
-	FreshTracks
-	Relly Softtware until 2018-01-01
+	Splunk
+	FreshTracks until 2018-11-01
+	Rally Software until 2018-01-01
 	Thetus Corporation until 2015-10-01
 	Pipeworks Software until 2014-01-01
 Chris Marchesi: chrism!vancluevertech.com, inbox!vancluevertech.com
@@ -7669,7 +7671,8 @@ Coderhypo: Coderhypo!users.noreply.github.com
 Codruț Constantin Gușoi: codrut.gusoi!gmail.com
 	NotFound
 Cody Boggs: cboggs!users.noreply.github.com
-	FreshTracks
+	Splunk
+	FreshTracks until 2018-11-01
 Cody Clark: codyclark!google.com, codyjtclark!gmail.com
 	Google
 Cody Littley: cjlittle!us.ibm.com


### PR DESCRIPTION
Bob Cotton, Cody Boggs, and Chris Marchbanks all moved from FreshTracks to Splunk at the end of 2018. Update affiliation list to reflect these changes.

cc: @cboggs, @bcotton