### PR TITLE
Fix affiliations for Ben Kochie

### DIFF
--- a/company_developers1.txt
+++ b/company_developers1.txt
@@ -19056,7 +19056,6 @@ IP Services:
 IPAs & APIs:
 	Sam Wierema: samwierema!gmail.com
 IPB:
-	Ben Kochie: superq!gmail.com, superq!users.noreply.github.com from 2017-10-01
 	sneumann: sneumann!ipb-halle.de
 IPC:
 	paul: paul!alfacloud.ltd until 2014-11-01

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -208,6 +208,7 @@ Independent:
 	Ben Gamari: ben!smart-cactus.org, bgamari.foss!gmail.com until 2015-06-01
 	Ben Harris: mail!bharr.is from 2012-10-15 until 2014-05-15
 	Ben Johnson: benbjohnson!yahoo.com
+	Ben Kochie: superq!gmail.com, superq!users.noreply.github.com from 2017-01-01
 	Ben Nemec: bnemec!redhat.com, bnemec!us.ibm.com, cybertron!users.noreply.github.com from 2013-07-12 until 2013-09-09
 	Ben Sykes: bsykes!netflix.com from 2017-11-01 until 2018-04-01
 	BenTheElder: ben.the.elder!gmail.com until 2015-05-01
@@ -18900,8 +18901,6 @@ RoadAR:
 	Andrey Chernih: andrey.chernih!gmail.com until 2014-07-15
 Rob Bast:
 	Rob Bast: rob.bast!gmail.com from 2015-08-01
-Robert Koch-institut:
-	Ben Kochie: superq!gmail.com, superq!users.noreply.github.com until 2017-10-01
 Robin Systems:
 	Chris Mildebrandt: chris!octarinesec.com, eyeofthefrog!users.noreply.github.com until 2017-04-01
 Roblox:

--- a/company_developers3.txt
+++ b/company_developers3.txt
@@ -1701,7 +1701,7 @@ SoundCloud:
 	Alexander Simmerl: alx!soundcloud.com
 	Alon Pe'er: alon.peer!soundcloud.com
 	Andrey Kuzmin: andrey.kuzmin!soundcloud.com, unsoundscapes!gmail.com from 2016-10-01
-	Ben Kochie: bjk!soundcloud.com
+	Ben Kochie: bjk!soundcloud.com, superq!gmail.com, superq!users.noreply.github.com until 2016-12-31
 	Bernerd Schaefer: bj.schaefer!gmail.com until 2014-09-01
 	Björn Rabenstein: bjoern!rabenste.in, bjoern!soundcloud.com from 2013-10-01 until 2019-04-01
 	Bora Tunca: bora!soundcloud.com, grandbora!users.noreply.github.com

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4774,8 +4774,8 @@ Ben Klein*: bklein!pivotal.io, fifthposition!users.noreply.github.com
 Ben Kochie*: bjk!soundcloud.com
 	SoundCloud
 Ben Kochie*: superq!gmail.com, superq!users.noreply.github.com
-	IPB
-	Robert Koch-institut until 2017-10-01
+	Independent from 2017-01-01
+	SoundCloud until 2016-12-31
 Ben Lambert: ben!blam.sh, benjdlambert!users.noreply.github.com
 	Just Football
 	Sky Betting&Gaming until 2017-01-01


### PR DESCRIPTION
* SoundCloud until 2016-12-31.
* Independent from 2017-01-01.

Signed-off-by: Ben Kochie <superq@gmail.com>