### PR TITLE
Fixed mixed emails for Robert and Peter

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -11431,7 +11431,7 @@ Peter Xu: peterx!redhat.com
 	Red Hat
 Peter Zijlstra: pzijlstr!redhat.com
 	Red Hat
-Peter Štibraný: peter.stibrany!grafana.com, robertfratto!gmail.com
+Peter Štibraný: peter.stibrany!grafana.com, pstibrany!gmail.com
 	Grafana Labs
 PeterDKC: PeterDKC!users.noreply.github.com
 	LinkedIn
@@ -15038,7 +15038,7 @@ Robert Foss: robert.foss!collabora.com
 	Collabora
 	CTO until 2016-04-01
 	ARM until 2015-03-01
-Robert Fratto: pstibrany!gmail.com, robert.fratto!grafana.com
+Robert Fratto: robert.fratto!grafana.com, robertfratto!gmail.com
 	Grafana Labs
 Robert Garrett: robertx.e.garrett!intel.com, robertx.garrett!intel.com
 	Intel


### PR DESCRIPTION
Something went wrong in commit f62f5447b42f58d551dc82740b9c35669f2d9a71 and then b7976ddd32f9dd84e64ddd4a4d0b4b0f6b7bc28c and Robert's and Peter's emails got mixed.
