### PR TITLE
Merge all affiliations related to MayaData Company

### DIFF
--- a/src/companies.yaml
+++ b/src/companies.yaml
@@ -16,4 +16,5 @@ acquisitions:
   - ['(?i)^(aws|amazon|amazon\s*aws|amazon\s*web\s*services|amazon\.com)$', Amazon]
   - ['(?i)^turbine\s*labs$', Slack]
   - ['(?i)^futurewei$', Huawei]
+  - ['(?i)^(openebs|cloudbyte)$', MayaData]
 #  - ['(?i)^red\s*hat$', IBM]


### PR DESCRIPTION
Signed-off-by: isamrish <askmaurya48@gmail.com>

This commit will add related code in `companies.yaml` for merging related affiliations of MayaData Company into One

**CloudByte => MayaData**
Initially Company name was CloudByte which renamed to MayaData

**OpenEBS**
OpenEBS is a project, not a company. It was started by MayaData.