### PR TITLE
sub-project repo was renamed to cluster-addons

### DIFF
--- a/src/repos.txt
+++ b/src/repos.txt
@@ -3354,6 +3354,7 @@
   kubernetes-sigs/cli-experimental,
   kubernetes-sigs/cli-utils,
   kubernetes-sigs/clife_cluster-api,
+  kubernetes-sigs/cluster-addons,
   kubernetes-sigs/cluster-api,
   kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm,
   kubernetes-sigs/cluster-api-provider-aws,

--- a/src/repos_cncf.txt
+++ b/src/repos_cncf.txt
@@ -545,6 +545,7 @@
   'kubernetes-sigs/cli-experimental',
   'kubernetes-sigs/cli-utils',
   'kubernetes-sigs/clife_cluster-api',
+  'kubernetes-sigs/cluster-addons',
   'kubernetes-sigs/cluster-api',
   'kubernetes-sigs/cluster-api-provider-aws',
   'kubernetes-sigs/cluster-api-provider-azure',


### PR DESCRIPTION
The Cluster Addons sub-project decided to use the `cluster-addons` name consistently across Github repo, Slack and elsewhere, cf https://github.com/kubernetes/org/issues/1583