### PR TITLE
Updating Samsung SDS member information

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -21284,7 +21284,7 @@ fooka03: fooka03!users.noreply.github.com, nigel.foucha!gmail.com
 	Bossa Nova Robotics from 2019-07-01
 foolusion: andrew.oneill!nordstrom.com, foolusion!gmail.com, foolusion!users.noreply.github.com
 	Nordstrom until 2017-05-31
-	Samsung SDS from 2017-05-31
+	Samsung SDS from 2017-05-31 until 2019-08-02
 fordhamae: fordhamae!users.noreply.github.com, github!fordhaminc.com
 	Independent
 forever043: majiuyue!huawei.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -2439,7 +2439,7 @@ jmvizcainoio: 44993815+jmvizcainoio!users.noreply.github.com, jmvizcainoio!users
 jmyounker: jeff!drinktomi.com, jmyounker!users.noreply.github.com
 	SavingGlobal
 jmyung: jesang.myung!gmail.com, jmyung!users.noreply.github.com
-	SAMSUNG
+	Samsung SDS
 jnativio: jnativio!us.ibm.com
 	IBM
 jnaulty: jnaulty!gmail.com, jnaulty!users.noreply.github.com, johnnaulty!bitgo.com
@@ -6311,7 +6311,7 @@ lead4good: frieder!paape.io, lead4good!users.noreply.github.com
 leafji: jiye01!inspur.com, leafji!126.com, leafji!users.noreply.github.com
 	Inspur
 leahnp: leahnp!users.noreply.github.com, leahnpetersen!gmail.com
-	Samsung SDS
+	Samsung SDS until 2018-08-03
 leakingtapan: chengpan!amazon.com, leakingtapan!users.noreply.github.com, longfei.zhang!easystack.cn
 	Amazon
 leandrocr: leandro.repolho!theiconic.com.au, leandrocr!users.noreply.github.com, leandrorepolho!gmail.com
@@ -7171,7 +7171,7 @@ losipiuk: losipiuk!users.noreply.github.com, lukasz!osipiuk.net, lukaszos!google
 lostick: 1172558+lostick!users.noreply.github.com, lostick!users.noreply.github.com, mevoyasf!gmail.com
 	Independent
 lostlivio: livio!arleo.net
-	Samsung SDS
+	Samsung SDS until 2019-11-22
 lostplan: sol!twitter.com, sol.plant!gmail.com
 	Twitter
 louberger: lberger!labn.net
@@ -8764,7 +8764,7 @@ mattez: kriz!codelab.cz, mattez!users.noreply.github.com
 	engine2 s.r.o.
 mattf: matt!cs.wisc.edu, matt!redhat.com, mattf!users.noreply.github.com
 	Red Hat
-mattfarina: matt!mattfarina.com, mattfarina!users.noreply.github.com, matthew.farina!hp.com, matthew.farina!hpe.com
+mattfarina: matt!mattfarina.com, mattfarina!users.noreply.github.com, matthew.farina!hp.com, matthew.farina!hpe.com, m.farina!samsung.com
 	HP until 2015-10-31
 	HP from 2015-10-31 until 2017-06-23
 	Innovating Tomorrow from 2017-06-23 until 2017-08-15
@@ -11109,7 +11109,7 @@ moondev: chad.d.moon!gmail.com, moondev!users.noreply.github.com
 	Heptio from 2018-10-01 until 2019-01-01
 	VMware from 2019-01-01
 moonek: gghonor!naver.com, moonek!users.noreply.github.com
-	Samsung
+	Samsung SDS
 mootpt: jay.wallace!doordash.com, jaycwallace!gmail.com, mootpt!users.noreply.github.com
 	bubblr until 2015-01-01
 	Puppet from 2015-01-01 until 2015-07-01
@@ -13190,7 +13190,7 @@ novel: bogorodskiy!gmail.com
 novemberborn: mark!novemberborn.net, novemberborn!users.noreply.github.com
 	Independent
 nowjean: cheapluv!gmail.com, nowjean!users.noreply.github.com
-	Samsung
+	Samsung SDS
 nownabe: nownabe!gmail.com, nownabe!users.noreply.github.com
 	IDC Frontier until 2016-05-01
 	Goodpatch from 2016-05-01 until 2017-07-01
@@ -13802,11 +13802,11 @@ onefrankguy: me!frankmitchell.org
 	FireForge until 2015-09-01
 	Rapid7 from 2015-09-01
 oneilcin: cubiedoo2!gmail.com, oneilcin!users.noreply.github.com
-	Samsung SDS
+	Samsung SDS until 2020-01-24
 oneonestar: oneonestar!gmail.com, oneonestar!users.noreply.github.com
 	Yahoo
 onesolpark: 32834020+onesolpark!users.noreply.github.com, onesolpark!gmail.com, onesolpark!users.noreply.github.com
-	Samsung
+	Samsung SDS
 oneswig: stig.github!telfer.org, stig.openstack!telfer.org
 	Cray until 2015-08-04
 	StackHPC from 2015-08-04
@@ -15169,7 +15169,7 @@ philmadden83: phil.madden!vividseats.com, philmadden83!gmail.com
 	Tribune Media Services until 2014-06-01
 	Vivid Seats from 2014-06-01
 philoserf: mark!philoserf.com, philoserf!users.noreply.github.com
-	Samsung SDS
+	Samsung SDS until 2019-02-08
 philpennock: phil+git!apcera.com, philpennock!users.noreply.github.com
 	Apcera until 2016-02-01
 	Taking a Break from 2016-02-01 until 2016-05-01
@@ -23862,7 +23862,7 @@ thaytan: jan!centricular.com, thaytan!noraisin.net
 thcdrt: thomas.coudert!corp.ovh.com
 	OVH
 thdrnsdk: thdrnsdk!naver.com, thdrnsdk!users.noreply.github.com
-	Samsung
+	Samsung SDS
 the-gigi: gigi-s!bigfoot.com, gigi.sayfan!helix.com, the-gigi!users.noreply.github.com, the.gigi!gmail.com
 	Bigfoot Entertainment
 the-redback: luuphu25!gmail.com, maruf!appscode.com, maruf.2hin!gmail.com, the-redback!users.noreply.github.com

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -2913,7 +2913,7 @@ yeliztaneroglu: yeliztaneroglu!gmail.com
 	Segmentify from 2017-12-01
 yenicapotediaz: yenicapote08!gmail.com, yenicapotediaz!gmail.com, yenicapotediaz!users.noreply.github.com
 	Independent until 2017-02-01
-	Samsung SDS from 2017-02-01
+	Samsung SDS from 2017-02-01 until 2019-02-04
 yepninja: petukhov.yevgeny!gmail.com, yepninja!users.noreply.github.com
 	Independent until 2016-05-01
 	HTML from 2016-05-01 until 2016-06-01
@@ -3526,7 +3526,7 @@ zachmandeville: zachmandeville!users.noreply.github.com, zz!ii.coop
 	StopTech from 2015-01-01
 zachpuck: zach.puckett!nintex.com, zachpuck!users.noreply.github.com, zachpuckett!gmail.com
 	Nintex until 2018-05-31
-	Samsung SDS from 2018-05-31
+	Samsung SDS from 2018-05-31 until 2019-06-19
 zachreizner: zachr!google.com
 	Google
 zachyee: zachyee!users.noreply.github.com


### PR DESCRIPTION
This is to provide a more accurate representation of the information.
Those in the Samsung category are Samsung Electronics employees.