### PR TITLE
Changed Bplotka affiliation.

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -31,7 +31,7 @@
 0xANDREW: 0xANDREW!users.noreply.github.com, andrew.wright502!gmail.com
 	Raiffeisen Bank Russia until 2014-02-01
 	Qiwi from 2014-02-01 until 2016-10-01
-	Tinkoff Bank from 2016-10-01
+	Tinkoff Bank from 2016-10-0bw1
 0xAX: 0xax!users.noreply.github.com, kuleshovmail!gmail.com
 	Travelping
 0xAhmed: ahmed!manhag.org
@@ -969,6 +969,10 @@ Bowenislandsong: Bowenislandsong!users.noreply.github.com, bsong!redhat.com
 	Red Hat
 BoyuanYan: BoyuanYan!users.noreply.github.com, boyuan!opennetworking.org, yanliuzhangyan!gmail.com
 	BUPT
+Bplotka: Bplotka!users.noreply.github.com, bwplotka!gmail.com
+	Intel until 2016-07-01
+	Improbable from 2016-07-01 until 2019-08-01
+	Red Hat from 2019-08-01
 BradErz: BradErz!users.noreply.github.com, bwilsonhunt!gmail.com
 	FACEIT
 Bradamant3: bradamant3!users.noreply.github.com, jrondeau!heptio.com

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -31,7 +31,7 @@
 0xANDREW: 0xANDREW!users.noreply.github.com, andrew.wright502!gmail.com
 	Raiffeisen Bank Russia until 2014-02-01
 	Qiwi from 2014-02-01 until 2016-10-01
-	Tinkoff Bank from 2016-10-0bw1
+	Tinkoff Bank from 2016-10-01
 0xAX: 0xax!users.noreply.github.com, kuleshovmail!gmail.com
 	Travelping
 0xAhmed: ahmed!manhag.org

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -969,8 +969,6 @@ Bowenislandsong: Bowenislandsong!users.noreply.github.com, bsong!redhat.com
 	Red Hat
 BoyuanYan: BoyuanYan!users.noreply.github.com, boyuan!opennetworking.org, yanliuzhangyan!gmail.com
 	BUPT
-Bplotka: Bplotka!users.noreply.github.com, bwplotka!gmail.com
-	Improbable
 BradErz: BradErz!users.noreply.github.com, bwilsonhunt!gmail.com
 	FACEIT
 Bradamant3: bradamant3!users.noreply.github.com, jrondeau!heptio.com


### PR DESCRIPTION
So at some point, I renamed in GitHub Bplotka -> bwplotka

Looks like `bwplotka` entry is correct, but `Bplotka` had wrong company affiliation. I don't know if that was causing devstats to show the wrong company name? :thinking: But cannot see anything else wrong here.

cc @caniszczyk do you think this will work? 

![image](https://user-images.githubusercontent.com/6950331/76343744-760a0100-62f8-11ea-86a8-21c81ae39b97.png)
