### PR TITLE
Delete gweon affiliation

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -171,8 +171,6 @@ gwei3: gang.wei!intel.com
 	Intel
 gwendalcr: gwendal!chromium.org
 	Google
-gweon: d.gweon!samsung.com, gweon!users.noreply.github.com
-	Samsung SDS
 gwik: antonin.amand!gmail.com, gwik!users.noreply.github.com
 	Zenly
 gwittel: gwittel!users.noreply.github.com


### PR DESCRIPTION
Delete gweon affiliation
It was duplicated.