### PR TITLE
Removing public Apple emails from company affiliations

### DIFF
--- a/src/cncf-config/domain-map
+++ b/src/cncf-config/domain-map
@@ -295,7 +295,6 @@ hyper.sh HyperHQ
 hystax.com Hystax
 ibm.com IBM
 ibp.de ipb (uk) Ltd.
-icloud.com Apple
 icplus.com.tw IC Plus
 ict.ac.cn ICT
 ifca.unican.es CSIC
@@ -399,7 +398,6 @@ maplelabs.com Maplelabs
 mapr.com MapR
 maprtech.com MapR
 marvell.com Marvell
-me.com Apple
 mellanox.co.il Mellanox
 mellanox.com Mellanox
 melware.de Cytronics & Melware


### PR DESCRIPTION
The Devstats for Apple registers public email domains as company affiliations, this removes those email domains from the CNCF config.

@lukaszgryglicki do I need to do anything to regenerate contributions?

Thanks!

Signed-off-by: Chris Hein <me@chrishein.com>