### PR TITLE
Removing @me.com and @icloud.com affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -305,7 +305,7 @@ AdrianGPrado: AdrianGPrado!users.noreply.github.com, adrian.garciaprado!nrg.com
 	TOTAL until 2015-09-15
 	NRG Energy from 2015-09-15
 AdrianPal: adrian.pal!me.com
-	Apple
+	Independent
 AerysNan: aerysnan!gmail.com
 	Independent
 AevaOnline: AevaOnline!users.noreply.github.com, devananda.vdv!gmail.com
@@ -332,7 +332,7 @@ Aisuko: Aisuko!users.noreply.github.com, urakiny!gmail.com
 	Neusoft from 2015-09-01 until 2016-11-01
 	Atos from 2016-11-01
 Ajido: Ajido!users.noreply.github.com, ajido!me.com
-	Apple
+	Independent
 Akado2009: Akado2009!users.noreply.github.com, prosvirov.k!gmail.com
 	Cisco
 Akash4927: Akash4927!users.noreply.github.com, akashsrivastava4927!gmail.com
@@ -465,7 +465,7 @@ AlginMaduro: alginmaduro!users.noreply.github.com
 Algodev-github: paolo.valente!linaro.org
 	Linaro
 Alienero: Alienero!users.noreply.github.com, yiyan.lu!me.com
-	Apple
+	Independent
 AllForNothing: AllForNothing!users.noreply.github.com, sshijun!vmware.com
 	VMware
 AllenZMC: AllenZMC!users.noreply.github.com, zhongming.chang!daocloud.io
@@ -709,7 +709,7 @@ Art3mK: Art3mK!users.noreply.github.com, artem!kayalaynen.ru
 	Protacon Solutions until 2017-05-01
 	Gofore from 2017-05-01
 Artazor: anatoly.ressin!icloud.com
-	Apple
+	Independent
 Artemy-Mellanox: artemyko!mellanox.com
 	Mellanox
 ArtfulCoder: ArtfulCoder!users.noreply.github.com, abshah!google.com
@@ -854,7 +854,7 @@ BasPH: basharenslak!godatadriven.com, basph!users.noreply.github.com
 Bastian-Krause: bst!pengutronix.de
 	Pengutronix
 BastianHofmann: bastianhofmann!me.com
-	Apple
+	Independent
 BastienL: BastienL!users.noreply.github.com, Rich!Sollenne.com, bastien.libersa!gmail.com, hello!bettysteger.com
 	ButterflyEffect until 2014-12-01
 	Citizen from 2014-12-01 until 2016-06-01
@@ -863,7 +863,7 @@ Batmat: Batmat!users.noreply.github.com, ml!batmat.net
 	Toulouse until 2016-08-01
 	CloudBees from 2016-08-01
 Baza207: baza207!me.com
-	Apple
+	Independent
 BearBabyLiu: liu.huang!zte.com.cn
 	ZTE
 Bege13mot: Bege13mot!users.noreply.github.com
@@ -1493,7 +1493,7 @@ CryptoCopter: CryptoCopter!users.noreply.github.com, markus!splork.de
 Cryptophobia: Cryptophobia!users.noreply.github.com, aouzounov!gmail.com
 	Teamhephy
 Cryrivers: cryrivers!me.com
-	Apple
+	Independent
 CsatariGergely: CsatariGergely!users.noreply.github.com, gergely.csatari!nokia.com
 	Nokia
 CydeWeys: CydeWeys!users.noreply.github.com, mcilwain!google.com
@@ -1546,7 +1546,7 @@ DXist: DXist!users.noreply.github.com, rinatshigapov!gmail.com
 DaJiaFeng: 1632530512!qq.com, DaJiaFeng!users.noreply.github.com, fufeng.lc!inspur.com
 	Inspur
 Daemeron: Daemeron!users.noreply.github.com, dabrowskip9!gmail.com, daemeron!icloud.com
-	Apple
+	Independent
 DaiHao: DaiHao!users.noreply.github.com, dh183333!antfin.com
 	Alipay
 Damenly: suy.fnst!cn.fujitsu.com
@@ -1854,7 +1854,7 @@ DorianZheng: DorianZheng!users.noreply.github.com, xingzhengde72!gmail.com, zhiq
 DoriftoShoes: DoriftoShoes!users.noreply.github.com, patrick!stackstorm.com
 	StackStorm
 DougSO: dougso!me.com, fexbef!gmail.com
-	Apple
+	Independent
 Dovgalyuk: pavel.dovgaluk!ispras.ru
 	ISP RAS
 Downchuck: Downchuck!users.noreply.github.com
@@ -2290,7 +2290,7 @@ Flydiverny: Flydiverny!users.noreply.github.com, markus!maga.se, markus!nadilus.
 	Tunstall AB from 2015-03-01 until 2016-12-01
 	jayway from 2016-12-01
 Fmowers: Fmowers!users.noreply.github.com, fmowers!icloud.com
-	Apple
+	Independent
 Fodoj: Fodoj!users.noreply.github.com, fodojyko!gmail.com
 	Open source until 2018-08-01
 	PAYBACK from 2018-08-01
@@ -2386,7 +2386,7 @@ GMinchAQ: v-glmin!microsoft.com
 GQH1993: gaiquanhe!foxmail.com, gaiquanhe!inspur.com, gqh1993!user.noreply.github.com
 	Inspur
 GaborWnuk: gabor.wnuk!me.com
-	Apple
+	Independent
 GabrielL: gabriel!lse.epita.fr
 	Epita
 GabrielNicolasAvellaneda: GabrielNicolasAvellaneda!users.noreply.github.com, avellaneda.gabriel!gmail.com
@@ -2479,7 +2479,7 @@ Globegitter: Globegitter!users.noreply.github.com, markus.padourek!ecosia.org, m
 	Hufsy from 2016-12-01 until 2018-12-01
 	Ecosia from 2018-12-01
 GnawNom: GnawNom!users.noreply.github.com, joewang!berkeley.edu
-	Apple
+	Independent
 Gnurou: acourbot!chromium.org, acourbot!nvidia.com, gnurou!gmail.com
 	NVidia until 2017-03-01
 	Google from 2017-03-01
@@ -3476,7 +3476,7 @@ KAGA164: KAGA164!users.noreply.github.com, kamil.gawor!nordicsemi.no
 KAZUMIZU: kazuya.mizuguchi.ks!renesas.com
 	Renesas Technology
 KCreate: leni.schuetz!me.com
-	Apple
+	Independent
 KEVINDIRU: 1029740643!qq.com, ding.rui!inspur.com, kevindiru!users.noreply.github.com
 	Inspur
 KFishner: kfishner!gmail.com, rob.roland!gmail.com
@@ -3707,7 +3707,7 @@ KoviaX: 32141052+koviax!users.noreply.github.com, KoviaX!users.noreply.github.co
 	Procam from 2016-12-01 until 2018-05-01
 	Alliander from 2018-05-01
 KraigWalker: kraig_walker!me.com
-	Apple
+	Independent
 Krinkle: Krinkle!users.noreply.github.com, krinklemail!gmail.com
 	Wikimedia
 KrzysztofCwalina: KrzysztofCwalina!users.noreply.github.com, kcwalina!microsoft.com
@@ -3736,7 +3736,7 @@ Kunde21: Kunde21!users.noreply.github.com, kunde21!gmail.com
 Kuqd: Kuqd!users.noreply.github.com, cyril.tovena!gmail.com, cyril.tovena!ubisoft.com
 	Ubisoft
 KuraFire: farukates!me.com
-	Apple
+	Independent
 KurtStam: KurtStam!users.noreply.github.com, kstam!redhat.com
 	Red Hat
 Kusanagi9999: Kusanagi9999!users.noreply.github.com, louis.woods!ericsson.com
@@ -3862,7 +3862,7 @@ Levovar: Levovar!users.noreply.github.com, levente.kale!nokia.com
 Lewis-Kang: kang!accton.com, lewis-kang!users.noreply.github.com
 	Accton
 Lewiscowles1986: lewiscowles!me.com
-	Apple
+	Independent
 Lewuathe: Lewuathe!users.noreply.github.com, lewuathe!me.com
 	Yahoo until 2015-10-01
 	Treasure from 2015-10-01 until 2016-10-01
@@ -4367,7 +4367,7 @@ Meligy: Meligy!users.noreply.github.com, eng.meligy!gmail.com
 MengZn: MengZn!users.noreply.github.com, adnt587!gmail.com
 	Nutc-Imac
 MerlinDMC: daniel.malon!me.com
-	Apple
+	Independent
 MesihK: mesihkilinc!gmail.com
 	Independent until 2015-08-01
 	CTech from 2015-08-01 until 2016-08-01
@@ -4494,7 +4494,7 @@ Mobrockers: mobrockers!gmail.com, mobrockers!users.noreply.github.com, rouke.bro
 	Independent from 2016-09-01 until 2017-01-01
 	Info Support from 2017-01-01
 MofeLee: MofeLee!users.noreply.github.com, mofe!me.com
-	Apple
+	Independent
 MohGeek: mohgeek!users.noreply.github.com, vollivier!live.fr
 	Nuglif
 MohamedBassem: MohamedBassem!users.noreply.github.com, medoox240!gmail.com
@@ -5164,7 +5164,7 @@ PuZZleDucK: PuZZleDucK+GitHub!gmail.com, puzzleduck!gmail.com
 Puigcerber: Puigcerber!users.noreply.github.com, pablo85!gmail.com
 	Independent
 PunKeel: PunKeel!users.noreply.github.com, punkeel!me.com
-	Apple
+	Independent
 PushkarJambhlekar: pushkar.iit!gmail.com
 	NVidia until 2015-07-01
 	Microsoft from 2015-07-01 until 2016-11-01
@@ -6001,7 +6001,7 @@ SkReD: SkReD!users.noreply.github.com, etienne.coutaud!pyxida.io, mshipov!yandex
 	EPITA from 2016-01-01 until 2016-12-01
 	CNCF from 2016-12-01
 Sky161: Sky161!users.noreply.github.com, andrey.chechkin!me.com
-	Apple
+	Independent
 SlawomirMrozowicz: slawomirx.mrozowicz!intel.com
 	Intel
 SlickNik: SlickNik!users.noreply.github.com, slicknik!gmail.com
@@ -6104,7 +6104,7 @@ StefanEnberg: StefanEnberg!users.noreply.github.com, seb!qlik.com
 	Qlik until 2018-08-01
 	Stratiteq from 2018-08-01
 StefanScherer: StefanScherer!users.noreply.github.com, peterkidson-github!spamarrest.com, scherer_stefan!icloud.com
-	Apple
+	Independent
 Steffen911: Steffen911!users.noreply.github.com, steffenschmitz!hotmail.de
 	SAP
 Stelminator: Stelminator!users.noreply.github.com, stelminator!gmail.com
@@ -6166,7 +6166,7 @@ Stono: Stono!users.noreply.github.com, me!karlstoney.com
 	ThoughtWorks from 2015-10-01 until 2017-11-01
 	Auto Trade UK from 2017-11-01
 Strajk: strajk!me.com
-	Apple
+	Independent
 Strech: Strech!users.noreply.github.com, oni.strech!gmail.com
 	distribusion
 StuartHarris: StuartHarris!users.noreply.github.com, stuart.harris!red-badger.com
@@ -6803,7 +6803,7 @@ Wadeck: wadeck!users.noreply.github.com, wadeck.follonier!gmail.com
 	Kudelski from 2016-04-01 until 2017-09-01
 	CloudBees from 2017-09-01
 Walliee: ansh.mehra!me.com
-	Apple
+	Independent
 WaltHP: walter.boring!hp.com
 	HP until 2015-10-31
 	HP from 2015-10-31 until 2016-10-28
@@ -6914,9 +6914,9 @@ XSAM: XSAM!users.noreply.github.com, sam.xie!liulishuo.com, xsambundy!gmail.com
 XSKY-Robot: haomai!xsky.io
 	XSky
 XVincentX: XVincentX!users.noreply.github.com, vennie1988!163.com, vincenz.chianese!icloud.com
-	Apple
+	Independent
 XZ-X: XZ-X!users.noreply.github.com, x1456776728!icloud.com
-	Apple
+	Independent
 XaF: raphael.beamonte!gmail.com
 	Independent until 2017-03-01
 	Morgan Stanley from 2017-03-01
@@ -7238,7 +7238,7 @@ aSquare14: atibhi.a!gmail.com
 	Independent from 2019-07-01 until 2020-01-01
 	CNCF from 2020-01-01
 aa-stripe: 43391988+aa-stripe!users.noreply.github.com, aa-stripe!users.noreply.github.com
-	Apple
+	Independent
 aaabramov: aaabramov!users.noreply.github.com, aabrasha!gmail.com
 	SoftServe until 2017-08-01
 	Tranzzo from 2017-08-01
@@ -7642,7 +7642,7 @@ achilles42: achilles42!users.noreply.github.com, praveen.shukla.c42!gmail.com
 	C42 Engineering from 2015-07-01 until 2016-02-01
 	Gojek from 2016-02-01
 achinthagunasekara: achintha!me.com, achinthagunasekara!users.noreply.github.com, adam!asaleh.net, contact!achinthagunasekara.com
-	Apple
+	Independent
 acim: acim!users.noreply.github.com, boban.acimovic!gmail.com, boban.acimovic!syncier.com
 	united-domains until 2015-07-01
 	Planet Sports from 2015-07-01 until 2015-09-01
@@ -9085,7 +9085,7 @@ alexey-mr: alexey-mr!users.noreply.github.com, alexey.morlang!gmail.com
 alexeykazakov: alkazako!redhat.com
 	Red Hat
 alexeyklyukin: alexeyklyukin!users.noreply.github.com, porkbird!icloud.com
-	Apple
+	Independent
 alexfouche: alexandre.fouche!gmail.com
 	basilic.io until 2014-06-01
 	Independent from 2014-06-01 until 2016-11-01
@@ -9141,7 +9141,7 @@ alexmt: alexander_matyushentsev!intuit.com, alexmt!users.noreply.github.com, ama
 	Applatix from 2016-08-01 until 2018-01-01
 	Intuit from 2018-01-01
 alexouzounis: alex.ouzounis!me.com, alexouzounis!users.noreply.github.com
-	Apple
+	Independent
 alexperovich: alperovi!microsoft.com
 	Microsoft
 alexpilotti: alexpilotti!users.noreply.github.com, apilotti!cloudbasesolutions.com
@@ -9323,7 +9323,7 @@ allamand: allamand!users.noreply.github.com, sebastien.allamand!orange.com
 allancaffee: allan.caffee!gmail.com, allancaffee!users.noreply.github.com
 	LinkedIn
 allanchau: allan.chau!icloud.com, allanchau!users.noreply.github.com
-	Apple
+	Independent
 allanlei: allanlei!helveticode.com, allanlei!users.noreply.github.com, boulabiar!gmail.com, ggrayban!hotmail.com
 	17media
 allanrenucci: allan.renucci!gmail.com, allanrenucci!users.noreply.github.com
@@ -9429,7 +9429,7 @@ alpha-san: alpha-san!users.noreply.github.com, awesomeplusplus!riseup.net, hello
 alphonsekurian: alkurian!microsoft.com
 	Microsoft
 alphonsekurian: alphonsekurian!icloud.com
-	Apple
+	Independent
 alq666: alq!datadoghq.com, alq666!users.noreply.github.com
 	Datadog
 alradmsft: alex.radutskiy!microsoft.com, mehran.ranji!gmail.com
@@ -10467,7 +10467,7 @@ antiroot-kr: antiroot!gmail.com
 	Samsung until 2014-03-01
 	Yet-another Challenges from 2014-03-01
 antlad: antlad!users.noreply.github.com, vlad.troinich!litmusautomation.com, vlad_troinich!icloud.com
-	Apple
+	Independent
 antmak: antmak.pub!gmail.com, anton!espressif.com
 	STC Yurion until 2016-04-01
 	Independent from 2016-04-01
@@ -10832,7 +10832,7 @@ argusua: argusua!users.noreply.github.com, dmitriy.kozlovskiy!onix-systems.com
 arh: alireza!cs.umn.edu
 	Independent
 arianf: arian!icloud.com
-	Apple
+	Independent
 ariava: avanzini.arianna!gmail.com
 	Gnome until 2014-08-01
 	NTOP from 2014-08-01 until 2015-07-01
@@ -11465,7 +11465,7 @@ astorije: jeremie!astori.fr
 	W3C until 2015-06-01
 	VMware from 2015-06-01
 astrahov: astrahov92!me.com
-	Apple
+	Independent
 astrajohn: astrajohn!users.noreply.github.com
 	AstraZeneca
 astraw38: as.fireflash38!gmail.com
@@ -11548,7 +11548,7 @@ aterreno: antonio.terreno!gmail.com
 	Equal Experts until 2017-07-01
 	Labradory from 2017-07-01
 athal7: athal7!me.com
-	Apple
+	Independent
 athampy: akhil!akhilthampy.com, akhilthampy!yahoo.com, athampy!users.noreply.github.com
 	JPMorgan
 athanatos: athanatos!users.noreply.github.com, rexludorum!gmail.com, sjust!redhat.com
@@ -11556,7 +11556,7 @@ athanatos: athanatos!users.noreply.github.com, rexludorum!gmail.com, sjust!redha
 	Red Hat from 2014-07-01 until 2017-02-01
 	SalesForce from 2017-02-01
 athei: alex.theissen!me.com, athei!users.noreply.github.com
-	Apple
+	Independent
 atheism: atheism.zhang!gmail.com
 	Red Hat
 athomason: ad!mthomason.net, athomason!users.noreply.github.com
@@ -11986,7 +11986,7 @@ azmelanar: azmelanar!users.noreply.github.com, dslupytskyi!gmail.com
 aznashwan: aznashwan!users.noreply.github.com, michael!autoscaled.io, nazhari!cloudbasesolutions.com, sovletig!gmail.com
 	Cloudbase Solutions
 azr: adrien.delorme!icloud.com, azr!users.noreply.github.com
-	Apple
+	Independent
 azweb76: azweb76!users.noreply.github.com, dan!azwebmaster.com, dclayton!godaddy.com
 	GoDaddy
 b-b3rn4rd: bernard!runawaylover.info
@@ -12173,7 +12173,7 @@ barnardb: barnardb!users.noreply.github.com
 	Independent from 2016-07-01 until 2017-02-01
 	Independent from 2017-02-01
 barney-s: barney-s!users.noreply.github.com, barni!google.com, bharanidharan!me.com
-	Apple
+	Independent
 baronomasia: baronomasia!users.noreply.github.com
 	LogDNA
 barp: barp!google.com, barp!users.noreply.github.com
@@ -12593,7 +12593,7 @@ benjaminws: benjaminwarfield!gmail.com, benjaminws!users.noreply.github.com
 	RTShare from 2017-03-01 until 2017-11-01
 	Datadog from 2017-11-01
 benjamminj: benjamin.d.johnson!icloud.com, benjamminj!users.noreply.github.com, marcus.vetter!live.com
-	Apple
+	Independent
 benjdlambert: ben!blam.sh, benjdlambert!users.noreply.github.com
 	BBC until 2016-11-01
 	Sky Betting&Gaming from 2016-11-01 until 2017-01-01
@@ -13166,7 +13166,7 @@ bkmeneguello: bkmeneguello!users.noreply.github.com, bruno!meneguello.com, githu
 	CodeIT Solutions until 2017-11-01
 	MATERA from 2017-11-01
 bkniffler: bkniffler!me.com
-	Apple
+	Independent
 bkochendorfer: bkochendorfer!users.noreply.github.com, brett.kochendorfer!gmail.com
 	Groupon until 2015-05-01
 	Cofounder from 2015-05-01 until 2016-06-01
@@ -13255,7 +13255,7 @@ bleungatchromium: bleung!chromium.org
 blgm: gblue!pivotal.io
 	Pivotal
 blia: kirill.yakovenko!me.com
-	Apple
+	Independent
 blimmer: ben!benlimmer.com, ben!ibotta.com, blimmer!users.noreply.github.com, hello!benlimmer.com
 	ReadyTalk until 2014-03-01
 	Ibotta from 2014-03-01 until 2020-01-01
@@ -13273,7 +13273,7 @@ blochl: lbloch!janustech.com, leonid!daynix.com
 bloodearnest: bloodearnest!gmail.com, bloodearnest!users.noreply.github.com
 	Canonical
 bloodyowl: mlbli!me.com
-	Apple
+	Independent
 blove: blove!users.noreply.github.com, brian!brianflove.com
 	Webucator until 2017-01-01
 	Independent from 2017-01-01 until 2018-04-01
@@ -13762,7 +13762,7 @@ brandonnelson3: brnelson!google.com
 brandonroberts: brandonroberts!users.noreply.github.com, robertsbt!gmail.com
 	CodeSequence
 brandonstephens: brandonstephens!me.com
-	Apple
+	Independent
 brandonweeks: brandonweeks!users.noreply.github.com, weeks!squareup.com
 	Square
 brantb: brantb!users.noreply.github.com
@@ -13811,7 +13811,7 @@ brejoc: brejoc!users.noreply.github.com, jbreuer!suse.de
 brenarth: brenarth!users.noreply.github.com, brendan.arthurs!ie.ibm.com
 	IBM
 brendanashworth: brendan.ashworth!me.com
-	Apple
+	Independent
 brendanburns: brendan.d.burns!gmail.com, brendanburns!users.noreply.github.com
 	Google until 2016-07-15
 	Microsoft from 2016-07-15
@@ -14437,7 +14437,7 @@ caf-zjzhang: zjzhang!codeaurora.org
 cafebabe: edward!0xcafebabe.co.uk
 	Sky
 cagataycali: cagataycali!icloud.com
-	Apple
+	Independent
 cagedmantis: cagedmantis!users.noreply.github.com, camedee!digitalocean.com
 	DigitalOcean
 cagiti: cagiti!users.noreply.github.com, caicooper82!gmail.com
@@ -14557,7 +14557,7 @@ camilosantana: camilo.santana!procore.com, camilosantana!users.noreply.github.co
 	I.AM+ from 2017-03-01 until 2018-04-01
 	Procore from 2018-04-01
 campbellwray: campbellwray!icloud.com
-	Apple
+	Independent
 campionfellin: campionfellin!users.noreply.github.com
 	Independent until 2015-06-01
 	Voice Box from 2015-06-01 until 2015-09-01
@@ -15174,7 +15174,7 @@ cgurnik: cgurnik!users.noreply.github.com
 cgwalters: cgwalters!users.noreply.github.com, walters!redhat.com, walters!verbum.org
 	Red Hat
 cgxu519: cgxu519!icloud.com
-	Apple
+	Independent
 ch-f: chf.fritz!googlemail.com
 	Independent
 ch33hau: ch33hau!gmail.com
@@ -15808,7 +15808,7 @@ chrisns: chris!cns.me.uk, chrisns!users.noreply.github.com
 chrisohaver: chrisohaver!gmail.com, chrisohaver!users.noreply.github.com, cohaver!infoblox.com
 	Infoblox
 chrisoverzero: chrisoverzero!me.com
-	Apple
+	Independent
 chrispsommers: 31145757+chrispsommers!users.noreply.github.com
 	Keysight
 chrisrgithub: chrisr!planetscale.com, chrisrgithub!users.noreply.github.com, radsurfer!gmail.com
@@ -16565,7 +16565,7 @@ coltonmorris: coltonmorris!users.noreply.github.com, coltonmorris94!gmail.com
 	Independent until 2016-06-15
 	TNC from 2016-06-15
 colus001: colus001!me.com
-	Apple
+	Independent
 combinatorist: combinatorist!users.noreply.github.com
 	Infospace until 2015-04-01
 	Independent from 2015-04-01 until 2015-08-01
@@ -17316,7 +17316,7 @@ cyphar: asarai!suse.com, asarai!suse.de, cyphar!cyphar.com, cyphar!users.noreply
 cyqsign: cyqsign!163.com
 	NetEase
 cyrez: m.groebner!me.com
-	Apple
+	Independent
 cyrilbur-ibm: cyril.bur!au1.ibm.com, cyrilbur!gmail.com
 	NICTA until 2013-12-01
 	IBM from 2013-12-01 until 2018-03-01
@@ -17515,7 +17515,7 @@ damemi: damemi!users.noreply.github.com, mdame!redhat.com
 damercie: daniel.mercier!autodesk.com
 	Autodesk
 damianoneill: damian.oneill!me.com, damianoneill!users.noreply.github.com
-	Apple
+	Independent
 damianpumar: damianpumar!users.noreply.github.com
 	Independent until 2014-06-01
 	Oleum from 2014-06-01 until 2014-12-01
@@ -17594,7 +17594,7 @@ danburkert: dan!danburkert.com, danburkert!users.noreply.github.com
 danc86: dcallagh!redhat.com
 	Red Hat
 dancasey: dc181!icloud.com
-	Apple
+	Independent
 dancing-elf: antonysaraev!gmail.com
 	Bifit until 2016-05-01
 	Independent from 2016-05-01 until 2016-12-01
@@ -17899,7 +17899,7 @@ darconeous: darco!deepdarc.com
 	Nest Labs until 2017-01-01
 	Google from 2017-01-01
 darcyadams: smadad!me.com
-	Apple
+	Independent
 dardok: dardok!users.noreply.github.com, dardokleiner!gmail.com, dkleiner!cmf.nrl.navy.mil
 	US Navy
 darend: darend!gmail.com, darend!users.noreply.github.com
@@ -17936,7 +17936,7 @@ dariopb: dario-simonetti!users.noreply.github.com
 	Independent from 2015-11-01 until 2016-01-01
 	Attest from 2016-01-01
 darkgaro: darkgaro!me.com, fbrbovic!devstub.com
-	Apple
+	Independent
 darkk: darkk!users.noreply.github.com, leon!darkk.net.ru
 	Papirus.net
 darkofabijan: alex!birkett.no, darko.fabijan!gmail.com, darkofabijan!users.noreply.github.com
@@ -19219,7 +19219,7 @@ dickwall: dick!bldc.org, dick!bldc.org, dickwall!users.noreply.github.com, dwall
 dictvm: daniel.heitmann!invision.de, dictvm!dictvm.org, dictvm!users.noreply.github.com
 	ivx
 didierfranc: didierfranc!me.com
-	Apple
+	Independent
 didrocks: didrocks!ubuntu.com, didrocks!users.noreply.github.com
 	Ubuntu
 die-kriegsmarine: die-kriegsmarine!users.noreply.github.com, die.kriegsmarine!gmail.com
@@ -19669,7 +19669,7 @@ dlim15: devin!onlab.us, devin!opennetworking.org
 	Independent from 2018-05-01 until 2018-08-01
 	Sony from 2018-08-01
 dlindenkreuz: dlindenkreuz!icloud.com, dlindenkreuz!users.noreply.github.com
-	Apple
+	Independent
 dlinsley: dlinsley!gmail.com, dlinsley!users.noreply.github.com
 	VMware
 dlipovetsky: daniel!platform9.com, dlipovetsky!users.noreply.github.com
@@ -20339,7 +20339,7 @@ drrt: dave!scytale.io, dirt!monkey.org, drrt!users.noreply.github.com
 	eatsa from 2015-11-01 until 2017-07-01
 	Scytale from 2017-07-01
 dru: andrey.melnik!icloud.com
-	Apple
+	Independent
 drubin: davidrub!gmail.com, drubin!users.noreply.github.com
 	SnapScan until 2016-02-01
 	FitKey from 2016-02-01 until 2016-07-01
@@ -20380,7 +20380,7 @@ dsapala: dsapala!users.noreply.github.com
 	The Learning until 2015-01-01
 	Illuminate from 2015-01-01
 dsblv: caleb!imakewebthings.com, daraujo!eslsistemas.com.br, disobolev!icloud.com, dsblv!users.noreply.github.com
-	Apple
+	Independent
 dschafer: dschafer!fb.com
 	Facebook
 dschaller: d_a_schaller!yahoo.com, dschaller!lyft.com, dschaller!users.noreply.github.com
@@ -20780,7 +20780,7 @@ dyusupov: dmitry!nexenta.com, dyusupov!users.noreply.github.com
 dzafman: dzafman!redhat.com, dzafman!users.noreply.github.com
 	Red Hat
 dzannotti: d.zannotti!me.com
-	Apple
+	Independent
 dzapata: dzapata!netflix.com, dzapata!users.noreply.github.com
 	OFICIOSVARIOS
 dzavalkinolx: dmytro.zavalkin!olx.com, dzavalkinolx!users.noreply.github.com
@@ -20954,7 +20954,7 @@ ebyhr: ebyhr!users.noreply.github.com, ebyhry!gmail.com
 ecashin: ecashin!coraid.com, ed.cashin!acm.org
 	Independent
 ecasilla: ecasilla!icloud.com
-	Apple
+	Independent
 ecejjar: ecejjar!users.noreply.github.com, j.javier.arauz!gmail.com, jesus.javier.arauz!ericsson.com
 	Ericsson
 echesakovMSFT: echesakovMSFT!users.noreply.github.com, egor.chesakov!microsoft.com
@@ -22239,7 +22239,7 @@ evankanderson: argent!google.com, evan.k.anderson!gmail.com, evankanderson!users
 	Google until 2019-12-15
 	VMware from 2019-12-15
 evanlucas: evanlucas!me.com, evanlucas!users.noreply.github.com
-	Apple
+	Independent
 evanscastonguay: evans.castonguay!gmail.com, evanscastonguay!users.noreply.github.com
 	Nuance Communications
 evdenis: efremov!linux.com, yefremov.denis!gmail.com
@@ -22601,7 +22601,7 @@ fasthall: fasthall!gmail.com, fasthall!users.noreply.github.com, weitsung!google
 fatalc: cnfatal!gmail.com, fatalc!users.noreply.github.com, zhanglikun!ghostcloud.cn
 	Ghostcloud
 fatcerberus: fatcerberus!icloud.com
-	Apple
+	Independent
 fate-grand-order: chenjg!harmonycloud.cn, fate-grand-order!users.noreply.github.com
 	HarmonyCloud
 fatih: fatih!users.noreply.github.com, ftharsln!gmail.com
@@ -23269,7 +23269,7 @@ francares: francares!users.noreply.github.com, francisco.m.casares!intel.com
 francesco-beccaria: fortiz!bitnami.com, francesco-beccaria!users.noreply.github.com, francesco.beccaria!gmail.com
 	Bitnami
 francescoinfante: fra.inf!icloud.com
-	Apple
+	Independent
 francescolavra: francescolavra.fl!gmail.com
 	Independent
 franciozzy: felipe!nutanix.com, felipe!paradoxo.org
@@ -23300,7 +23300,7 @@ frankenmichl: mmoese!suse.de
 frankfarzan: frankf!google.com, frankfarzan!users.noreply.github.com
 	Google
 frankgreco: fbgrecojr!me.com, frankgreco!users.noreply.github.com
-	Apple
+	Independent
 frankjiao: frankjiao!users.noreply.github.com, jiaojianfeng!baidu.com
 	Baidu
 franklin-stripe: franklin-stripe!users.noreply.github.com
@@ -23309,7 +23309,7 @@ franklin-stripe: franklin-stripe!users.noreply.github.com
 franklinwise: franklin!krave.io, franklinwise!users.noreply.github.com
 	Krave-n
 frankreno: frank.reno!me.com, frankreno!users.noreply.github.com
-	Apple
+	Independent
 frankstratton: epanastasi!epanastasi.com, frank!runscope.com
 	Runscope until 2017-09-01
 	CA from 2017-09-01 until 2018-12-01
@@ -23670,7 +23670,7 @@ galal-hussein: galal-hussein!users.noreply.github.com, hussein.galal.ahmed.11!gm
 galbramc: galbramc!mit.edu
 	MIT
 galenandrew: galen.turner!me.com
-	Apple
+	Independent
 galexandrov: georgi.alexandrov!telerik.com
 	Progress
 galexrt: Galexrt!googlemail.com
@@ -23759,7 +23759,7 @@ gaoxm: gaoxm!users.noreply.github.com
 gaozhenhai: gaozh1988!live.com, gaozhenhai!users.noreply.github.com
 	tenxcloud
 gaplo917: logap!me.com
-	Apple
+	Independent
 gaplyk: gaplyk!users.noreply.github.com, oleksii.khliupin!nytimes.com
 	The New York Times
 gardleopard: gard.rimestad!schibsted.com, gardhr!gmail.com, gardleopard!gmail.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -56,7 +56,7 @@ guineveresaenger: guineveresaenger!github.com, guineveresaenger!gmail.com, guine
 	Samsung SDS until 2018-09-01
 	GitHub from 2018-09-01
 guisouza: betaver!gmail.com, bpent3l!gmail.com, gui_souza!me.com, quinn.jacobd!gmail.com
-	Apple
+	Indep
 guits: gabrioux!redhat.com, guits!users.noreply.github.com
 	Red Hat
 gujingit: gujingit!users.noreply.github.com
@@ -1911,7 +1911,7 @@ iennae: WangJinPing2013!gmail.com, iennae!gmail.com, iennae!users.noreply.github
 	RealSelf from 2018-02-01 until 2018-10-01
 	Microsoft from 2018-10-01
 iest: hello_iest!me.com, iest!me.com
-	Apple
+	Independent
 ifed01: ifed!mail.ru, ifedotov!suse.com, rahul.303!gmail.com
 	SUSE
 ifigotin: ifigotin!google.com
@@ -1954,7 +1954,7 @@ igncp: icarbajop!gmail.com, igncp!users.noreply.github.com
 	Independent from 2016-08-01 until 2016-10-01
 	Accedo. from 2016-10-01
 ignertic: 19890921!qq.com, ignertic!icloud.com, ignertic!users.noreply.github.com
-	Apple
+	Independent
 igoihman: igoihman!redhat.com, igoihman!users.noreply.github.com
 	Red Hat
 igor-stoppa: igor.stoppa!gmail.com
@@ -2122,7 +2122,7 @@ ilovett: i.c.lovett!gmail.com, ilovett!users.noreply.github.com, mpdesouza!suse.
 	Quantum from 2017-05-01 until 2018-02-01
 	River Rock Apps from 2018-02-01
 ilovezfs: ilovezfs!icloud.com, ilovezfs!users.noreply.github.com
-	Apple
+	Independent
 ilyacompulab: ilya!compulab.co.il
 	CompuLab
 ilyasotkov: ilya!sotkov.com, ilyasotkov!users.noreply.github.com
@@ -2138,7 +2138,7 @@ imantung: iman.tung!gmail.com
 	Gojek from 2015-05-01 until 2019-04-01
 	Tiket from 2019-04-01
 imasen: igor.masen!icloud.com
-	Apple
+	Independent
 imazik: imazik!users.noreply.github.com, shovan.cse91!gmail.com, shovan.maity!mayadata.io
 	Independent until 2015-12-01
 	DISARM from 2015-12-01 until 2016-01-01
@@ -2183,7 +2183,7 @@ imjoey: imjoey!users.noreply.github.com, majunjiev!gmail.com
 imkin: dbhanushali!vmware.com, dhawal.bhanushali!outlook.com, imkin!users.noreply.github.com
 	VMware
 immannino: tonymannino!me.com
-	Apple
+	Independent
 immutableT: alextc!google.com, atcherniakhovski!gmail.com, immutableT!users.noreply.github.com
 	Microsoft until 2016-10-01
 	Google from 2016-10-01
@@ -2691,7 +2691,7 @@ j-xiong: jianxin.xiong!intel.com
 j00ru: j00ru.vx!gmail.com, mjurczyk!google.com
 	Google
 j03wang: j03wang!users.noreply.github.com, joewang!berkeley.edu
-	Apple
+	Independent
 j0k3r: j0k3r!users.noreply.github.com, jeremy.benoist!gmail.com
 	Groupe L'Express until 2016-03-01
 	20 Minutes France from 2016-03-01
@@ -2957,7 +2957,7 @@ jamesog: james!netinertia.co.uk, jamesog!users.noreply.github.com
 jamespic: james.pickering!hermes-europe.co.uk, james_pic!hotmail.com, jamespic!users.noreply.github.com
 	Aire Logic
 jamesr73: jamesr73!users.noreply.github.com, jamesr73.github!icloud.com
-	Apple
+	Independent
 jamesrichard91: jamesrichard91!gmail.com, jrichard!synopsys.com
 	Black Duck until 2017-12-01
 	Synopsys from 2017-12-01
@@ -2996,7 +2996,7 @@ jamiehannaford: jamie!limetree.org, jamiehannaford!github.com, jamiehannaford!us
 	Rackspace until 2018-01-01
 	GitHub from 2018-01-01
 jamiehodge: jamiehodge!me.com, jhodge!zendesk.com
-	Apple
+	Independent
 jamieiles: jamie!jamieiles.com, jamie.iles!oracle.com
 	Oracle
 jamiekrug: jamiekrug!gmail.com, jamiekrug!users.noreply.github.com
@@ -3104,7 +3104,7 @@ jannickfahlbusch: git!jf-projects.de, jannickfahlbusch!users.noreply.github.com
 jannikbecher: becher.jannik!gmail.com
 	Independent
 janolivermr: janolivermr!users.noreply.github.com, janstolle!me.com
-	Apple
+	Independent
 janos-ss: janos-ss!users.noreply.github.com, janos.gyerik!sonarsource.com
 	Société Générale until 2016-08-01
 	SonarSource from 2016-08-01
@@ -3183,7 +3183,7 @@ jaredmorgs: jaredleonmorgan {at} gmail {dot} {com}, jaredleonmorgan!gmail.com
 jaredpar: jaredpar!microsoft.com
 	Microsoft
 jarimatti: jarimatti!me.com, jarimatti!users.noreply.github.com
-	Apple
+	Independent
 jarodwilson: jarod!redhat.com
 	Red Hat
 jarondl: me!jarondl.net
@@ -3273,7 +3273,7 @@ jasonk000: jasonk!bluedevel.com, jasonk000!users.noreply.github.com, jkoch!netfl
 jasonkeene: jasonkeene!users.noreply.github.com, jkeene!pivotal.io
 	Pivotal
 jasonkuhrt: jason.kuhrt!dialogue.co, jasonkuhrt!me.com
-	Apple
+	Independent
 jasonlkx: jasonlkx!users.noreply.github.com, liu.kexin!inspur.com
 	Inspur
 jasonmelo: gitjason!gmail.com, jason.melo!gmail.com
@@ -3454,7 +3454,7 @@ jaypipes: jaypipes!gmail.com, jaypipes!users.noreply.github.com
 	Oath from 2018-06-01 until 2019-05-01
 	Amazon from 2019-05-01
 jayrylan: jeremyrylan!me.com
-	Apple
+	Independent
 jaytaylor: jaytaylor!users.noreply.github.com, outtatime!gmail.com, outtatime+github!gmail.com
 	Gigawatt IO
 jayunit100: jay!apache.org, jay!platform9.com, jayunit100!github.com, jayunit100!users.noreply.github.com, jayunit100.apache!gmail.com, jvyas!blackducksoftware.com, jvyas!redhat.com, jvyas!vmware.com
@@ -4136,7 +4136,7 @@ jessesleeping: jessesleeping!users.noreply.github.com, jiexil!fb.com
 	Independent from 2016-08-01 until 2017-02-01
 	Facebook from 2017-02-01
 jessestuart: alanspurlock!hotmail.com, hi!jessestuart.com, jdstuart!icloud.com, jessestuart!users.noreply.github.com
-	Apple
+	Independent
 jessesuen: jessesuen!gmail.com, jessesuen!users.noreply.github.com
 	Tintri until 2016-03-01
 	Applatix from 2016-03-01 until 2018-01-01
@@ -4833,7 +4833,7 @@ jmahler: jmmahler!gmail.com
 	Independent until 2016-04-01
 	Amazon from 2016-04-01
 jmaitrehenry: julien!kumojin.com, julien.maitrehenry!me.com
-	Apple
+	Independent
 jmaneyrol: jmaneyrol!invensense.com
 	Movea until 2014-07-01
 	TDK from 2014-07-01
@@ -5074,7 +5074,7 @@ joe-elliott: joe-elliott!users.noreply.github.com, joe.elliott!grafana.com, numb
 joe-lawrence: joe.lawrence!redhat.com
 	Red Hat
 joe11051105: joe11051105!users.noreply.github.com, joewang!berkeley.edu, wangjoe1105!gmail.com
-	Apple
+	Independent
 joe2far: joe2far!users.noreply.github.com, joe2farrell!gmail.com
 	Ammeon until 2017-08-01
 	Jet from 2017-08-01
@@ -5085,7 +5085,7 @@ joeauty: joe!datasprocket.com, joeauty!users.noreply.github.com
 	NanoPay from 2014-12-01 until 2017-04-01
 	ThinkData Works from 2017-04-01
 joeblackwaslike: joeblackwaslike!me.com, joeblackwaslike!users.noreply.github.com, me!joeblack.nyc
-	Apple
+	Independent
 joecar-: joe.carnuccio!qlogic.com
 	QLogic
 joecritch: joecritch!gmail.com, joecritch!users.noreply.github.com, simeonsamson4!gmail.com
@@ -5157,7 +5157,7 @@ joewstroman: joewstroman!gmail.com
 joeyb: joey!joeyb.org, joeyb!users.noreply.github.com
 	SalesForce
 joeych18: joey.ch!me.com
-	Apple
+	Independent
 joeyimbasciano: joeyi!google.com, joeyimbasciano!users.noreply.github.com
 	Google
 joeyparrish: joeyparrish!google.com
@@ -5262,7 +5262,7 @@ johnhofman: johncarlhofman!gmail.com, johnhofman!users.noreply.github.com
 johnhubbard: jhubbard!nvidia.com
 	NVidia
 johnjansen: john!dreamware.nz, john.jansen!me.com
-	Apple
+	Independent
 johnjbarton: johnjbarton!johnjbarton.com, johnjbarton!users.noreply.github.com
 	Google
 johnjmaguire: johnjmaguire!users.noreply.github.com
@@ -5527,7 +5527,7 @@ jonschoning: jonschoning!gmail.com, jonschoning!users.noreply.github.com
 	Redbox until 2018-02-01
 	Polaris from 2018-02-01
 jonsie: chrissmalley!me.com
-	Apple
+	Independent
 jonsmorrow: jmorrow!chef.io
 	Chef
 jonstacks: jonstacks!users.noreply.github.com, jonstacks13!gmail.com
@@ -5540,7 +5540,7 @@ jonwallg: jonwall!google.com
 jonyhy96: haoyun!ghostcloud.cn, jonyhy96!users.noreply.github.com
 	Independent
 jonyonson: contact!rael.io, jonyonson!icloud.com
-	Apple
+	Independent
 joonas: joonas!bergi.us, joonas!digitalocean.com, joonas!users.noreply.github.com, joonas.bergius!gmail.com
 	DigitalOcean until 2019-01-01
 	NetApp from 2019-01-01 until 2019-07-01
@@ -6178,7 +6178,7 @@ jszwedko: jesse!szwedko.me, jesse.szwedko!gmail.com, jszwedko!users.noreply.gith
 	City and County of San Francisco from 2017-10-01 until 2018-09-01
 	Timber.io from 2018-09-01
 jt143: justinhuang!me.com
-	Apple
+	Independent
 jtattermusch: jan.tattermusch!gmail.com, jtattermusch!google.com, jtattermusch!users.noreply.github.com
 	Google
 jtblin: jtblin!atlassian.com, jtblin!gmail.com, jtblin!users.noreply.github.com
@@ -6260,7 +6260,7 @@ juangascon: juan.gascon!orange.com
 juangutierrez: jgutierrez!ti.com
 	Texas Instruments
 juankaram: public.juan.karam!me.com
-	Apple
+	Independent
 juanluisbaptiste: juan.baptiste!gmail.com, juanluisbaptiste!users.noreply.github.com
 	CacheSimple until 2017-01-01
 	Akam SRL from 2017-01-01
@@ -7345,7 +7345,7 @@ kelvincheung: keguang.zhang!gmail.com
 	Independent until 2018-04-01
 	UNISOC from 2018-04-01
 kemcake: erik!neo.org, kemcake!users.noreply.github.com, santos.remi!icloud.com
-	Apple
+	Independent
 kemicoco: kemi.wang!intel.com
 	Intel
 kemitche: kemi.krm!gmail.com, kemitche!users.noreply.github.com
@@ -7809,7 +7809,7 @@ king6cong: king6cong!gmail.com, king6cong!users.noreply.github.com
 kingproxj: kingproxj!users.noreply.github.com, xujun!inspur.com, xujun_2008!163.com
 	Inspur
 kingsleyh: kingsleyhendrickse!me.com
-	Apple
+	Independent
 kinow: bruno.kinoshita!niwa.co.nz, brunodepaulak!yahoo.com.br, kinow!apache.org, kinow!users.noreply.github.com
 	Boa Vista SCPC until 2016-04-01
 	NIWA from 2016-04-01 until 2016-09-01
@@ -8308,7 +8308,7 @@ kpettijohn: kpettijohn!esri.com, pettijohn.k!gmail.com
 kpfleming: kpfleming!bloomberg.net
 	Bloomberg
 kpgriffith: kpgriffith!me.com, kpgriffith!users.noreply.github.com, vyacheslav.donchak!devexpress.com
-	Apple
+	Independent
 kpjani: ketanjani21!gmail.com, kpjani!users.noreply.github.com
 	IBM
 kpjeeja: jeeja.kp!intel.com
@@ -8768,7 +8768,7 @@ kwladyka: kwladyka!users.noreply.github.com
 kwmonroe: kevin.monroe!canonical.com, kwmonroe!users.noreply.github.com
 	Canonical
 kwoods: woodsk!me.com
-	Apple
+	Independent
 kxxoling: kxxoling!gmail.com, kxxoling!users.noreply.github.com
 	pine
 kyakan: sicilia.cristian!gmail.com
@@ -8872,7 +8872,7 @@ l15k4: l15k4!users.noreply.github.com, liska.jakub!gmail.com
 l1x: l1x!users.noreply.github.com
 	Lambda Insight
 l2dy: l2dy!icloud.com, l2dy!users.noreply.github.com
-	Apple
+	Independent
 l2fprod: l2fprod!users.noreply.github.com
 	IBM
 labadav: ifnikitt!google.com
@@ -9379,7 +9379,7 @@ lentzi90: lennart.jern!gmail.com, lentzi90!users.noreply.github.com
 	Elastisys from 2017-06-01 until 2018-01-01
 	Elastisys from 2018-01-01
 leo: leo!users.noreply.github.com, leo!zeit.co, mindrun!icloud.com, rainstorm.armiie!gmail.com
-	Apple
+	Independent
 leobaran-aws: leobaran!amazon.com
 	Independent until 2016-05-01
 	Amazon from 2016-05-01
@@ -9478,7 +9478,7 @@ levsa: levon.sa!gmail.com
 levy-amir: amir.jer.levy!intel.com
 	Intel
 lewisdaly: lewis!vesselstech.com, lewisdaly!me.com, lewisdaly!users.noreply.github.com
-	Apple
+	Independent
 lewisheadden: lewis!lewisheadden.com, lewis_headden!condenast.com, lewisheadden!users.noreply.github.com
 	AetherWorks until 2014-11-01
 	Condé Nast from 2014-11-01 until 2019-02-01
@@ -9573,7 +9573,7 @@ lichen2013: lichen2013!users.noreply.github.com, shchenli!cn.ibm.com
 lichuqiang: agrare!redhat.com, guangtian_li!qq.com, lichuqiang!huawei.com, lichuqiang!users.noreply.github.com
 	Huawei
 lidalei: 454909522!qq.com, dalei.li!icloud.com, lidalei!users.noreply.github.com
-	Apple
+	Independent
 lidderupk: ilyoan!gmail.com, lidderupk!gmail.com, neues!interaktionsweise.de
 	IBM
 liding09: liding09!users.noreply.github.com
@@ -10196,7 +10196,7 @@ lostplan: sol!twitter.com, sol.plant!gmail.com
 louberger: lberger!labn.net
 	LabN
 louis-langholtz: lou_langholtz!me.com
-	Apple
+	Independent
 louis-murray: congfairy2536!gmail.com, louis-murray!users.noreply.github.com, oscar.99.tris!gmail.com, playa1!gmail.com, steffen.butzer!outlook.com
 	Independent until 2015-08-01
 	Petroleum from 2015-08-01 until 2015-09-01
@@ -10459,7 +10459,7 @@ luizbafilho: luizbafilho!gmail.com, luizbafilho!users.noreply.github.com
 luizcarraro: Sovietaced!gmail.com, luizcarraro!me.com, luizcarraro!users.noreply.github.com, steve!doublec.biz
 	Big Switch Networks
 luk-: luke!hatetheinter.net, luke.arduini!me.com
-	Apple
+	Independent
 lukanus: lukanus!uaznia.net
 	Mezzobit until 2015-09-01
 	Coders Mill from 2015-09-01 until 2016-12-01
@@ -10718,7 +10718,7 @@ m-niesluchow: m.niesluchow!samsung.com
 m-nikhil: m-nikhil!users.noreply.github.com
 	Cisco
 m-s-austin: m_austin!me.com
-	Apple
+	Independent
 m-schen: 983362525!qq.com, chenmingsong!inspur.com, m-schen!users.noreply.github.com
 	Inspur
 m-seldin: m-seldin!users.noreply.github.com, michael.seldin!hpe.com
@@ -10743,7 +10743,7 @@ m3brown: michael.brown!cfpb.gov
 m3ngyang: m3ngyang!users.noreply.github.com, yangm3ng!gmail.com
 	Baidu
 m42u: emmanuel.v!me.com, m42u!users.noreply.github.com
-	Apple
+	Independent
 m4burns: m4burns!users.noreply.github.com, m4burns!uwaterloo.ca
 	Beatlight until 2016-04-01
 	D2L from 2016-04-01 until 2016-12-01
@@ -10922,7 +10922,7 @@ maggieneterval: mneterval!google.com
 maggiepint: maggie!tempworks.com, maggiepint!gmail.com, maggiepint!users.noreply.github.com, magpint!microsoft.com
 	Microsoft
 magicalbob: ellisia!me.com, ian!ellisbs.co.uk
-	Apple
+	Independent
 magicsong: dh.rpcs3!gmail.com
 	yunify
 magicwang-cn: magicwang-cn!users.noreply.github.com, wangbowang.wang!huawei.com
@@ -10932,7 +10932,7 @@ magicyang168: magicyang168!163.com, magicyang168!users.noreply.github.com
 magnayn: nigel.magnay!gmail.com
 	Allocate Software
 magnolia-k: magnolia.k!icloud.com
-	Apple
+	Independent
 magnoliatitanium: alexandra.yates!linux.intel.com
 	Intel
 magomez: magomez!igalia.com
@@ -11417,9 +11417,9 @@ marisidd: basavaraju.marisiddaiah!hpe.com
 mariusae: marius!monkey.org, marius!twitter.com
 	Twitter
 mariusgrigoriu: marius.grigoriu!me.com, mariusgrigoriu!users.noreply.github.com
-	Apple
+	Independent
 mariusschulz: marius.schulz!me.com
-	Apple
+	Independent
 mariusz-r: mariusz.ryndzionek!firmwave.com
 	MpicoSys Embedded until 2016-05-01
 	Firmwave from 2016-05-01
@@ -11539,7 +11539,7 @@ markyzq: mark.yao!rock-chips.com
 marler8997: johnnymarler!gmail.com, marler8997!users.noreply.github.com
 	HP
 marlon360: m.lueckert!me.com, marlon360!users.noreply.github.com
-	Apple
+	Independent
 marob: marob!smile.fr, robert.maxime!gmail.com
 	Smile
 marok: mariusz.okroj!intel.com
@@ -11732,7 +11732,7 @@ masteinhauser: masteinhauser!users.noreply.github.com, myles.steinhauser!gmail.c
 	Bose from 2017-06-01 until 2019-07-01
 	ASICS from 2019-07-01
 masterfung: thung!me.com
-	Apple
+	Independent
 masterlittle: goyalshitij!gmail.com
 	Independent until 2015-07-01
 	Grofers from 2015-07-01 until 2018-10-01
@@ -11863,7 +11863,7 @@ matt-deboer: matt-deboer!users.noreply.github.com, matt.deboer!gmail.com
 	Costco Wholesale until 2016-08-01
 	Getty Images from 2016-08-01
 matt-farmer: matt-farmer!users.noreply.github.com, solversurfer!icloud.com
-	Apple
+	Independent
 matt-kwong: matt-kwong!users.noreply.github.com
 	Symantec
 matt-kwong: mattkwong!google.com
@@ -11874,7 +11874,7 @@ matt-magaldi: matt-magaldi!users.noreply.github.com
 	Independent from 2015-07-01 until 2016-08-01
 	BlackRock from 2016-08-01
 matt-paul: mattpaul001!icloud.com
-	Apple
+	Independent
 matt-potter: matt-potter!users.noreply.github.com, matthew.potter!uswitch.com, me!mattpotter.co.uk
 	Movable Ink
 matt-turner-skyscanner: matt-turner-skyscanner!users.noreply.github.com, matt.turner!skyscanner.net, matturner!gmail.com
@@ -11937,7 +11937,7 @@ matthewbobrowski: mbobrowski!mbobrowski.org
 matthewcarleton: matthewcarleton!users.noreply.github.com, mcarleto!redhat.com, mcarleton!redhat.com
 	Red Hat
 matthewdias: matthewdias!me.com
-	Apple
+	Independent
 matthewdunsdon: matthewdunsdon!gmail.com, matthewdunsdon!users.noreply.github.com
 	Scott Logic
 matthewdupre: matt!tigera.io, matthew.dupre!metaswitch.com, matthewdupre!users.noreply.github.com
@@ -12584,7 +12584,7 @@ mdaverde: mdaverde!users.noreply.github.com, milanlandaverde!gmail.com
 	Mobiquity from 2014-05-15 until 2014-11-15
 	Wikibuy from 2014-11-15
 mdcanham: mdcanham!me.com
-	Apple
+	Independent
 mde: mde!fleegix.org, mde!users.noreply.github.com
 	Microsoft until 2014-04-01
 	Independent from 2014-04-01 until 2015-01-01
@@ -12790,7 +12790,7 @@ meling: hein.meling!uis.no, meling!users.noreply.github.com
 mellanoxbmc: vadimp!mellanox.com
 	Mellanox
 mellena1: andrew_mellen!icloud.com, andy1030!me.com, mellena1!users.noreply.github.com
-	Apple
+	Independent
 mellinoe: erme!microsoft.com, mellinoe!gmail.com, mellinoe!users.noreply.github.com
 	Microsoft until 2017-10-01
 	Independent from 2017-10-01 until 2018-08-01
@@ -12851,7 +12851,7 @@ merge: martin.kepplinger!ginzinger.com, martink!posteo.de
 mergeconflict: mergeconflict!google.com, mergeconflict!users.noreply.github.com
 	Google
 meridional: meridional!users.noreply.github.com, yeji1989!me.com
-	Apple
+	Independent
 meringu: meringu!gmail.com, meringu!users.noreply.github.com
 	Xero
 merlin2030: hemaolin!inspur.com, merlin2030!users.noreply.github.com
@@ -12880,7 +12880,7 @@ meskio: clarkbaker!gmail.com, meskio!sindominio.net
 	MOMENTUM TASK FORCE from 2015-12-01 until 2017-02-01
 	Sanitas from 2017-02-01
 messense: messense!icloud.com
-	Apple
+	Independent
 mestery: kmestery!cisco.com, mestery!mestery.com, mestery!users.noreply.github.com
 	Cisco until 2014-09-26
 	HP from 2014-09-26 until 2015-10-09
@@ -13093,7 +13093,7 @@ mhamdisemah: mhamdi.semah!gmail.com, mhamdisemah!users.noreply.github.com
 mhamrah: m!hamrah.com, mhamrah!users.noreply.github.com
 	Uber
 mhamwala: eyphkatriangle!gmail.com, mhamwala!users.noreply.github.com, musahamwala!icloud.com
-	Apple
+	Independent
 mhassanpur: mhassanpur!gmail.com
 	Sling Media until 2014-03-01
 	Scanadu from 2014-03-01 until 2015-07-01
@@ -13206,7 +13206,7 @@ michael-o: michaelo!apache.org
 michael-w-williams: 31933474+michael-w-williams!users.noreply.github.com, michael.w.williams!oracle.com
 	Oracle
 michaelajr: michael.andrews!me.com, michaelajr!users.noreply.github.com
-	Apple
+	Independent
 michaelbausor: michaelbausor!google.com, michaelbausor!users.noreply.github.com
 	Google
 michaelcullum: m!michaelcullum.com, michaelcullum!users.noreply.github.com
@@ -13236,7 +13236,7 @@ michaelgugino: gugino.michael!yahoo.com, mgugino!redhat.com, michaelgugino!users
 michaelhpe: weimin.jing!hpe.com
 	HP
 michaeljfazio: michaelfazio!me.com
-	Apple
+	Independent
 michaeljohnbennett: michael-k!users.noreply.github.com, michaeljohnbennett!users.noreply.github.com
 	VMware
 michaeljqzq: michaeljqzq!gmail.com, michaeljqzq!users.noreply.github.com
@@ -13246,7 +13246,7 @@ michaelkipper: michael!kipper.ca, michaelkipper!users.noreply.github.com
 michaelklishin: michael!clojurewerkz.org, michael!novemberain.com, michaelklishin!users.noreply.github.com
 	Pivotal
 michaelmccaskill: michael.mccaskill!cengage.com, michael.mccaskill!me.com, michaelmccaskill!users.noreply.github.com
-	Apple
+	Independent
 michaelneale: michael.neale!gmail.com, michaelneale!users.noreply.github.com, mneale!cloudbees.com
 	CloudBees
 michaelolbrich: m.olbrich!pengutronix.de
@@ -13394,7 +13394,7 @@ miguelaeh: devgorri!gmail.com, macabrera!bitnami.com, miguelaeh!users.noreply.gi
 	Bitnami from 2019-03-01 until 2019-05-01
 	VMware from 2019-05-01
 miguelaferreira: miguelaferreira!users.noreply.github.com, miguelferreira!me.com
-	Apple
+	Independent
 miguelbernadi: ahutalla!gmail.com, miguel.bernabeu!lobber.eu, miguelbernadi!gmail.com, miguelbernadi!users.noreply.github.com
 	Centro Nacional de Análisis Genómico (CNAG-CRG) until 2016-08-01
 	Devex from 2016-08-01
@@ -13953,7 +13953,7 @@ mjtrangoni: mario!mariotrangoni.de, mjtrangoni!gmail.com, mjtrangoni!users.norep
 mjura: mjura!suse.com, mjura!users.noreply.github.com
 	SUSE
 mk01: matuskral () me com, matuskral!me.com, mk01!users.noreply.github.com
-	Apple
+	Independent
 mkainy: mkainy!users.noreply.github.com
 	LSIS
 mkalderon: michal.kalderon!cavium.com
@@ -14286,7 +14286,7 @@ mnuttall: mnuttall!uk.ibm.com, mnuttall!users.noreply.github.com, mpnuttall!gmai
 moander: m!qse.no, moander!users.noreply.github.com, morten!vianett.no
 	ViaNett AS
 mobi-robert: mobi-robert!users.noreply.github.com, robert.rabe1!icloud.com
-	Apple
+	Independent
 mobile-enerlytics: ajindal!mobileenerlytics.com
 	Mobile Enerlytics
 mocyuto: yuutoo.advance!gmail.com
@@ -14404,7 +14404,7 @@ monkindey: monkindey!163.com, monkindey!icloud.com
 monnand: dengnan!google.com, monnand!gmail.com
 	Google
 monners: joshmoncrieff!me.com
-	Apple
+	Independent
 monopole: jeff.regan!gmail.com, jregan!google.com, monopole!users.noreply.github.com
 	Google
 monotek: andre.bauer!kiwigrid.com, monotek!users.noreply.github.com, monotek23!gmail.com
@@ -14697,7 +14697,7 @@ mrbobbytables: bob.killen!linux.com, killen.bob!gmail.com, mrbobbytables!users.n
 mrbobfrog: bvandenheuvel!schubergphilis.com, mrbobfrog!users.noreply.github.com
 	Schuberg Philis
 mrbrownt: mrbrownt!me.com, mrbrownt!users.noreply.github.com
-	Apple
+	Independent
 mrcrane: michael.crane!gmail.com
 	Microsoft
 mrdfuse: mrdfuse!users.noreply.github.com, nico.mommaerts!gmail.com
@@ -14900,7 +14900,7 @@ msmeissn: meissner!suse.de, msmeissn!users.noreply.github.com
 msmith: mike!sticknet.net, msmith!users.noreply.github.com
 	WP Engine
 msmorgan: morgan.michael!me.com
-	Apple
+	Independent
 msnelling: mark!bakedbeans.com, msnelling!users.noreply.github.com
 	Solaise Capital Management
 msoap: msoap!users.noreply.github.com, sergey.mudrik!gmail.com
@@ -14935,7 +14935,7 @@ msschl: fahim!codexi.com, ivailo98!gmail.com, markus_schlotbohm!as-gmbh.de, mssc
 mssola: hendrix.alex87!gmail.com, mikisabate!gmail.com, mssola!users.noreply.github.com
 	SUSE
 mst: marcelst!me.com
-	Apple
+	Independent
 mstahl-iis: manuel.stahl!iis.fraunhofer.de
 	Independent
 mstemm: mark.stemm!gmail.com, mark.stemm!sysdig.com, mstemm!users.noreply.github.com
@@ -15770,7 +15770,7 @@ ndechesne: nicolas.dechesne!linaro.org
 ndelangen: kdasu.kdev!gmail.com
 	Broadcom
 ndelangen: ndelangen!me.com
-	Apple
+	Independent
 ndeloof: ndeloof!users.noreply.github.com, nicolas.deloof!gmail.com
 	Docker
 ndesh26: n.deshmukh!samsung.com, ndesh26!users.noreply.github.com
@@ -16038,7 +16038,7 @@ nhuray: nhuray!users.noreply.github.com, nicolas.huray!gmail.com
 	Badsintown from 2016-05-01 until 2018-05-01
 	Estateably from 2018-05-01
 nhw76: nhw!me.com, nhw76!users.noreply.github.com
-	Apple
+	Independent
 nibalizer: krum.spencer!gmail.com, nibalizer!users.noreply.github.com, nibz!cat.pdx.edu, nibz!spencerkrum.com, spencer.krum!hp.com
 	Independent until 2013-06-16
 	UTi Worldwide from 2013-06-16 until 2014-06-16
@@ -16163,7 +16163,7 @@ nicolaevladescu: nicolaevladescu!users.noreply.github.com
 nicolaferraro: ni.ferraro!gmail.com, nicolaferraro!users.noreply.github.com
 	Red Hat
 nicolai86: nicolai86!me.com, nicolai86!users.noreply.github.com
-	Apple
+	Independent
 nicolaiskogheim: nicolai.skogheim!gmail.com, nicolaiskogheim!users.noreply.github.com
 	Jimmy Royal until 2013-12-15
 	Independent from 2013-12-15
@@ -16680,7 +16680,7 @@ notnoopci: mahmood!circleci.com, notnoopci!users.noreply.github.com
 notque: notque!gmail.com, notque!users.noreply.github.com
 	SAP
 notrab: hi_jamie!me.com, jamie!notrab.dev
-	Apple
+	Independent
 notsu: chilly.notsu!gmail.com, notsu!users.noreply.github.com
 	Dek-D Interactive
 notxcain: notxcain!gmail.com, notxcain!users.noreply.github.com
@@ -17871,7 +17871,7 @@ pantoniou: pantelis.antoniou!konsulko.com, panto!antoniou-consulting.com
 	NVidia until 2014-12-01
 	Konsulko from 2014-12-01
 pantoss: pantoss!me.com, pantoss!users.noreply.github.com
-	Apple
+	Independent
 panywei: yanwei.pan!gmail.com
 	Google
 paoloantinori: pantinor!redhat.com, paoloantinori!users.noreply.github.com, sonicaaaa!gmail.com
@@ -18228,7 +18228,7 @@ paveq: paavo.pokkinen!vaimo.com, paveq!users.noreply.github.com
 pavhofman: pavel.hofman!ivitera.com
 	IVITERA
 pavlin99th: pavlin99th!me.com
-	Apple
+	Independent
 pavolloffay: p.loffay!gmail.com, pavolloffay!users.noreply.github.com, ploffay!redhat.com
 	Honeywell until 2015-03-01
 	Red Hat from 2015-03-01 until 2017-02-01
@@ -18806,7 +18806,7 @@ philipbjorge: philipbjorge!gmail.com, philipbjorge!users.noreply.github.com
 philipgian: f.giannakos!gmail.com, philipgian!users.noreply.github.com
 	GRNET
 philiphaas: philiphaas!me.com, philiphaas!users.noreply.github.com
-	Apple
+	Independent
 philipp-spiess: hello!philippspiess.com, pengxiaolong!camera360.com, philipp-spiess!users.noreply.github.com
 	Bitstem until 2015-06-01
 	NTRY Ticketing OG from 2015-06-01 until 2016-10-01
@@ -18979,7 +18979,7 @@ pietern: pnoordhuis!vmware.com
 	VMware until 2016-02-01
 	Facebook from 2016-02-01
 pieterv-icloud-com: pieterv!icloud.com, pieterv-icloud-com!users.noreply.github.com
-	Apple
+	Independent
 pietromenna: pietromenna!gmail.com, pietromenna!users.noreply.github.com
 	SAP
 pigletfly: pigletfly!users.noreply.github.com, wangbing.adam!gmail.com
@@ -19477,7 +19477,7 @@ pplavetzki: pplavetzki!users.noreply.github.com
 	Juniper Networks from 2016-06-01 until 2019-09-01
 	Microsoft from 2019-09-01
 pposkrobko: pawel.poskrobko!icloud.com, pposkrobko!users.noreply.github.com
-	Apple
+	Independent
 pprindeville: philipp!redfish-solutions.com
 	Redfish until 2018-11-01
 	Gigamon from 2018-11-01
@@ -19627,7 +19627,7 @@ premanandc: premanandc!gmail.com, premanandc!users.noreply.github.com
 	ThoughtWorks until 2015-06-15
 	Barclaycard from 2015-06-15
 premist: premist!me.com, premist!users.noreply.github.com
-	Apple
+	Independent
 premkarat: pkarat!mvista.com
 	MontaVista
 presidentbeef: justin!presidentbeef.com, presidentbeef!users.noreply.github.com
@@ -19850,7 +19850,7 @@ ptone: preston!ptone.com, ptone!users.noreply.github.com
 ptrnull: 1756381+ptrnull!users.noreply.github.com, ptrnull!users.noreply.github.com
 	Red Hat
 ptux: ooocamel!icloud.com, ptux!users.noreply.github.com
-	Apple
+	Independent
 puckchen: puck.chen!hisilicon.com
 	Hisilicon
 puckpuck: pierre!pierretessier.com, puckpuck!users.noreply.github.com
@@ -20113,7 +20113,7 @@ qsdchenwei: 591097974!qq.com, chenwei2017!inspur.com, qsdchenwei!users.noreply.g
 qsn: sd!queasysnail.net
 	Independent
 quamen: gareth.townsend!me.com
-	Apple
+	Independent
 quamilek: kamil.wargula!allegrogroup.com, kwargula!gmail.com, me!prajith.in
 	Allegro
 quanPhamvan: quan.pham_van!nokia.com
@@ -21041,7 +21041,7 @@ relaxdiego: mmaglana!gmail.com, relaxdiego!users.noreply.github.com
 remingtonc: code!remington.io, remcampb!cisco.com, remingtonc!users.noreply.github.com
 	Cisco
 remixz: zbruggeman!me.com
-	Apple
+	Independent
 remoe: remo.eichenberger!gmail.com, remoe!users.noreply.github.com
 	ETH Zurich
 remohammadi: info!rolandkuhn.com, j.vd.merwe!enovision.net, remohammadi!gmail.com, remohammadi!users.noreply.github.com, reza!cafebazaar.ir
@@ -21093,7 +21093,7 @@ reshnm: rene.schuenemann!gmail.com, rene.schuenemann!sap.com, reshnm!users.norep
 resios: andrei.resios!gmail.com, resios!amazon.com
 	Amazon
 resker: alexei.led!gmail.com, esker!me.com, resker!users.noreply.github.com
-	Apple
+	Independent
 resouer: harryz!hyper.sh, harryzhang!zju.edu.cn, lei.zhang!alibaba-inc.com, lz.llcb07!alibaba-inc.com, resouer!163.com, resouer!gmail.com, resouer!users.noreply.github.com
 	HyperHQ until 2018-03-01
 	Microsoft from 2018-03-01 until 2018-06-01
@@ -21139,7 +21139,7 @@ reube: reube!users.noreply.github.com
 	SPARK from 2014-06-01 until 2018-09-01
 	Stronghold from 2018-09-01
 reubn: reuben.eggar!me.com
-	Apple
+	Independent
 reverson: reverson!users.noreply.github.com, robert!reverson.net
 	Google until 2014-11-01
 	Netflix from 2014-11-01 until 2015-12-01
@@ -21382,7 +21382,7 @@ rickypai: ricky.pai!airbnb.com, rickyp999!gmail.com, rickyp999+github!gmail.com,
 rickysarraf: office!suits.at, rickysarraf!users.noreply.github.com, rrs!debian.org, rrs!researchut.com
 	Debian
 ricokahler: ricokahler!me.com, ricokahler!users.noreply.github.com
-	Apple
+	Independent
 ricolin: rico.lin.guanyu!gmail.com, ricolin!users.noreply.github.com
 	inwinSTACK until 2017-02-24
 	EasyStack from 2017-02-24
@@ -21797,7 +21797,7 @@ robertpanzer: robert.panzer!me.com, robert.panzer.pb!googlemail.com, robertpanze
 	Tomitribe from 2016-02-01 until 2016-10-01
 	Walmart from 2016-10-01
 robertscherbarth: r.scherbarth!icloud.com, robertscherbarth!users.noreply.github.com
-	Apple
+	Independent
 robertsigler: robert.sigler!thomsonreuters.com, robert.sigler!tr.com
 	Maverick until 2015-05-01
 	Thomson Reuters from 2015-05-01 until 2015-09-01
@@ -21975,7 +21975,7 @@ rodvdka: rodneyhawkins!gmail.com
 	Independent from 2017-09-01 until 2018-06-01
 	takealot from 2018-06-01
 roemba: r.hendrikx!me.com, roemba!users.noreply.github.com
-	Apple
+	Independent
 roganw: quangenw!gmail.com
 	上海易路软件有限公司
 rogerhu: rhu!hearsaycorp.com, roger.hu!gmail.com
@@ -21986,7 +21986,7 @@ rogeriorps: rogerio.pimentel!freescale.com
 rogerq: rogerq!ti.com
 	Texas Instruments
 rogerwelin: roger.welin!icloud.com, rogerwelin!users.noreply.github.com
-	Apple
+	Independent
 roguishmountain: paulofelipe.feitosa!gmail.com, roguishmountain!gmail.com, samsch!microsoft.com
 	Microsoft
 rohan47: rohan47!users.noreply.github.com, rohanrgupta1996!gmail.com, rohgupta!redhat.com
@@ -22173,7 +22173,7 @@ rosko: a!insvit.com, rosko!users.noreply.github.com
 ross-p-smith: ross-p-smith!users.noreply.github.com
 	Microsoft
 rossbachp: peter.rossbach!bee42.com, peterrossbach!me.com, rossbachp!users.noreply.github.com
-	Apple
+	Independent
 rosscdh: rosscdh!users.noreply.github.com
 	LawPal until 2014-10-01
 	ManualONE from 2014-10-01 until 2016-09-01
@@ -23789,7 +23789,7 @@ seano314: seano314!users.noreply.github.com
 	Softchoice until 2015-03-15
 	Tableau from 2015-03-15
 seanpeters86: sean.peters86!icloud.com, seanpeters86!users.noreply.github.com
-	Apple
+	Independent
 seanqsun: sean!seanqsun.com, sesun!redhat.com
 	Red Hat
 seans3: seans!google.com, seans3!gmail.com, seans3!users.noreply.github.com
@@ -23906,7 +23906,7 @@ seh: seh!panix.com, seh!uber.com, seh!users.noreply.github.com, seharris!us.ibm.
 seils: seils!users.noreply.github.com, zachseils!google.com
 	Google
 seivan: opspectrum!icloud.com, seivan!users.noreply.github.com, seivan.heidari!icloud.com
-	Apple
+	Independent
 seiyapl: adam-26!users.noreply.github.com
 	Mesosphere
 sel: sel!users.noreply.github.com
@@ -24092,7 +24092,7 @@ seushermsft: seushermsft!users.noreply.github.com
 sevein: jesus!sevein.com, juraj.suchan!gmail.com, sevein!users.noreply.github.com
 	Independent
 sevenfourk: sevenfourk!icloud.com, sevenfourk!users.noreply.github.com
-	Apple
+	Independent
 seyyah: nurettin.senyer!gmail.com, s3yyah.m3!gmail.com
 	Independent
 sezeresen: sezeresen!users.noreply.github.com
@@ -24706,7 +24706,7 @@ shtripat: shtripat!redhat.com, shtripat!users.noreply.github.com, shubhendu.trip
 shu-mutou: shu-mutou!rf.jp.nec.com, shu-mutou!users.noreply.github.com, shu.mutow!gmail.com
 	NEC
 shuaibird: shuaibird!icloud.com
-	Apple
+	Independent
 shubham-kumar-sharma: 36513419+shubham-kumar-sharma!users.noreply.github.com, shubham-kumar-sharma!users.noreply.github.com
 	Oracle
 shubham14bajpai: shubham.bajpai!mayadata.io, shubham14bajpai!gmail.com, shubham14bajpai!users.noreply.github.com
@@ -24742,7 +24742,7 @@ shuheiktgw: shuhei.kitagawa!c-fo.com, shuheiktgw!users.noreply.github.com
 	BizReach from 2016-04-01 until 2016-11-01
 	freee 株式会社 from 2016-11-01
 shuji-koike: shuji-koike!users.noreply.github.com, shuji.koike!me.com
-	Apple
+	Independent
 shumingfan: shumingf!realtek.com
 	Realtek Semiconductor
 shun-miyoshi-com: s.miyoshi!jp.fujitsu.com, shun-miyoshi-com!users.noreply.github.com
@@ -24880,7 +24880,7 @@ silentdai: lambdai!google.com, silentdai!gmail.com, silentdai!users.noreply.gith
 silentpete: peter.gallerani!gmail.com, silentpete!users.noreply.github.com
 	Polaris Alpha
 silentroach: igor.kalashnikov!me.com, silentroach!users.noreply.github.com, zhigang1992!gmail.com
-	Apple
+	Independent
 silhouettes: rich!rkhua.com, rihua!microsoft.com
 	Microsoft
 sils: kevincryan23!gmail.com, lasse!schuirmann.net, sils!users.noreply.github.com

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -34,7 +34,7 @@ sonicz: sonic.zhang!analog.com
 soninaren: nasoni!microsoft.com, soninaren!live.com, soninaren!users.noreply.github.com
 	Independent
 sonnysideup: bernhardkohler!icloud.com, sonnygarcia!icloud.com, sonnysideup!users.noreply.github.com
-	Apple
+	Independent
 sonnyvan: sonnyvan!users.noreply.github.com, sv!gatech.edu
 	UC Davis until 2015-04-01
 	UMDOC from 2015-04-01 until 2016-05-01
@@ -611,7 +611,7 @@ startnow65: startnow65!gmail.com, startnow65!users.noreply.github.com
 	Interswitch from 2015-05-01 until 2018-07-01
 	HelloFresh from 2018-07-01
 startswithaj: jake.mc!icloud.com
-	Apple
+	Independent
 stash: jeremy!goinstant.com, jstash!gmail.com, lrekucki+github!gmail.com, stash!users.noreply.github.com
 	SalesForce until 2017-12-01
 	Independent from 2017-12-01 until 2018-06-01
@@ -769,7 +769,7 @@ stephensmalley: sds!tycho.nsa.gov
 stephentoub: stephentoub!users.noreply.github.com, stoub!microsoft.com
 	Microsoft
 stephenway: stephencway!me.com
-	Apple
+	Independent
 steren: steren!users.noreply.github.com, steren.giannini!gmail.com
 	Sketchfab until 2014-05-01
 	Google from 2014-05-01
@@ -782,7 +782,7 @@ stettberger: christian.dietrich!informatik.uni-erlangen.de, stettberger!dokucode
 steuhs: 36011612+steuhs!users.noreply.github.com, steuhs!users.noreply.github.com
 	Google
 steve-jansen: stevejansen_github!icloud.com
-	Apple
+	Independent
 steve-perkins: nobodyzxc.tw!gmail.com, steve!steveperkins.com, steve-perkins!users.noreply.github.com
 	BatterCloud
 steve-perkins-bc: steve!steveperkins.com, steve-perkins-bc!users.noreply.github.com
@@ -1374,7 +1374,7 @@ superhighfives: cgleason!heroku.com, russell-github!stuart.id.au, superhighfives
 	Unbound until 2017-06-01
 	Heroku from 2017-06-01
 superlaziness: shemyakin!me.com
-	Apple
+	Independent
 superm1: mario.limonciello!dell.com, mario_limonciello!dell.com
 	Dell
 supermarin: supermarin!users.noreply.github.com
@@ -1733,7 +1733,7 @@ t0mk: t0mk!users.noreply.github.com, tom.to.the.k!gmail.com
 t1: ruediger.dohna!codecentric.de, snackbox!sinntr.eu
 	Codecentric AG
 t3chnoboy: dmitry.mazuro!icloud.com
-	Apple
+	Independent
 t4ku: t4ku!users.noreply.github.com
 	Enigmo
 t8m: tmraz!redhat.com
@@ -2033,7 +2033,7 @@ tariq1890: taibrahi!microsoft.com, tariq.ibrahim!microsoft.com, tariq181290!gmai
 	Microsoft from 2018-05-01 until 2019-03-01
 	SalesForce from 2019-03-01
 tarnfeld: tarnfeld!me.com
-	Apple
+	Independent
 tarokkk: tarokkk!users.noreply.github.com
 	Independent until 2015-06-01
 	IBM from 2015-06-01 until 2018-02-01
@@ -2091,7 +2091,7 @@ taylorwaggoner: 34756611+taylorwaggoner!users.noreply.github.com, taylorwaggoner
 	Jive until 2017-11-01
 	CNCF from 2017-11-01
 taylorwood: taylorwood!me.com
-	Apple
+	Independent
 tazjin: tazjin!gmail.com, tazjin!users.noreply.github.com
 	Goonswarm
 tback: tback!users.noreply.github.com, till!backha.us
@@ -2123,7 +2123,7 @@ tbird20d: tim.bird!sony.com
 tbm: tbm!cyrius.com
 	Software Freedom Conservancy
 tbodt: tblodt!icloud.com
-	Apple
+	Independent
 tbosch: tbosch!users.noreply.github.com, tbosch1009!gmail.com
 	Google
 tbouvet: thierry.bouvet!mpsa.com
@@ -2229,7 +2229,7 @@ tdz: contact!tzimmermann.org, tdz!users.sourceforge.net
 tealee1992: liqilong!baidu.com, tealee1992!users.noreply.github.com
 	Baidu
 tealtail: allydevour!me.com, tealtail!protonmail.com
-	Apple
+	Independent
 teamsoo: phakin.che!gmail.com, teamsoo!users.noreply.github.com
 	Connectiv until 2014-03-01
 	DST from 2014-03-01 until 2014-09-01
@@ -2240,7 +2240,7 @@ teawater: teawater!126.com, teawater!hyper.sh, teawater!users.noreply.github.com
 tebrandt: todd.e.brandt!linux.intel.com
 	Intel
 techdragon: lucractius!me.com, techdragon!users.noreply.github.com
-	Apple
+	Independent
 technosophos: matt.butcher!microsoft.com, mbutcher!deis.com, mbutcher!engineyard.com, technosophos!gmail.com, technosophos!users.noreply.github.com
 	Revolv until 2014-10-15
 	Nest from 2014-10-15 until 2015-06-15
@@ -2676,7 +2676,7 @@ thiagomacieira: thiago!macieira.org, thiago.macieira!intel.com, thiagomacieira!u
 thiagophx: thiagophx!gmail.com
 	Stylight
 thibaultcha: thibaultcha!me.com, thibaultcha!users.noreply.github.com
-	Apple
+	Independent
 thiblahute: thibault.saunier!osg.samsung.com, tsaunier!gnome.org
 	Samsung
 thibserot: alex!noldorin.com, thibserot!gmail.com, thibserot!users.noreply.github.com
@@ -2759,7 +2759,7 @@ thomasmey: thomas!m3y3r.de
 thomaso-mirodin: thomas!databricks.com, thomaso-mirodin!users.noreply.github.com
 	Databricks
 thomaspink: sterren.fisher!hotmail.co.uk, thomas.pink!me.com, wohlin2!icloud.com
-	Apple
+	Independent
 thomaspugliese: thomas.pugliese!gmail.com
 	Alereon until 2017-10-01
 	Apple from 2017-10-01
@@ -2782,7 +2782,7 @@ thomastaylor312: taylor!oftaylor.com, taylor.thomas!microsoft.com, thomastaylor3
 thomasvl: thomasvl!google.com, thomasvl!users.noreply.github.com
 	Google
 thomaswelton: thomaswelton!me.com
-	Apple
+	Independent
 thomaswk: thomaswk!google.com
 	Google
 thomedw: thomas!katalisindonesia.com
@@ -2983,7 +2983,7 @@ timdorr: git!timdorr.com, timdorr!timdorr.com, timdorr!users.noreply.github.com
 	SalesLoft from 2017-06-01 until 2019-09-01
 	Deft from 2019-09-01
 timeimp: timp_members!me.com
-	Apple
+	Independent
 timfpark: timfpark!gmail.com, timfpark!users.noreply.github.com
 	Microsoft
 timja: t.jacomb!kainos.com, tim.jacomb!hmcts.net, timja!users.noreply.github.com, timjacomb1+github!gmail.com
@@ -3789,7 +3789,7 @@ trampi: fabian.trampusch!freenet.de
 	iSYS until 2018-04-01
 	ALAX from 2018-04-01
 trappar: jarrod!jarrodyellets.com, jeff.way!me.com
-	Apple
+	Independent
 trask: trask!users.noreply.github.com, trask.stalnaker!gmail.com
 	Wolters Kluwer ELM Solutions until 2019-04-01
 	Microsoft from 2019-04-01
@@ -3929,7 +3929,7 @@ troygoode: troygoode!gmail.com, troygoode!users.noreply.github.com
 	Winmore until 2019-01-01
 	Courier from 2019-01-01
 troywilson: troywilson!me.com, troywilson!users.noreply.github.com
-	Apple
+	Independent
 trshafer: thomasjshafer!gmail.com, trshafer!users.noreply.github.com, tshafer!google.com
 	Google
 trsqr: olli.salonen!iki.fi
@@ -3965,7 +3965,7 @@ trwegner: trwegner!users.noreply.github.com
 trwegner: twegner!microsoft.com
 	Azure
 trxcllnt: paul.e.taylor!me.com
-	Apple
+	Independent
 tryantwit: tryant90!gmail.com
 	Valcom until 2018-04-01
 	Ozmo from 2018-04-01
@@ -4027,7 +4027,7 @@ tsloughter: t!crashfast.com, tsloughter!users.noreply.github.com
 tsmetana: tomas!smetana.name, tsmetana!redhat.com, tsmetana!users.noreply.github.com
 	Red Hat
 tsoome: tsoome!me.com
-	Apple
+	Independent
 tspaeth: info!conserata.com, info!spaeth.org, ts!conserata.com, tspaeth!users.noreply.github.com
 	conserata IT
 tspanindra: ptumkurseetharamu!godaddy.com, tumkurs2!illinois.edu
@@ -4541,7 +4541,7 @@ usarid: usarid!gmail.com
 ushatil: uri.shatil!cloudtp.com
 	Cloud Technology Partners
 usiegj00: usiegj00!me.com
-	Apple
+	Independent
 utako: utakoueda!gmail.com, utakoueda+github!gmail.com, uueda!pivotal.io
 	Pivotal
 uthark: oatamanenko!eastbanctech.com, oleg.atamanenko!gmail.com, uthark!users.noreply.github.com
@@ -5293,7 +5293,7 @@ vipulsabhaya: vipul.sabhaya!hp.com, vipuls!gmail.com, vipulsabhaya!users.noreply
 vireshk: viresh.kumar!linaro.org, viresh.linux!gmail.com
 	Linaro
 virlstd: ejkern!mac.com
-	Apple
+	Independent
 virtualhops: amonge!juniper.net
 	Juniper Networks
 virtuoso: alexander.shishkin!linux.intel.com, ash!koowaldah.org
@@ -5559,7 +5559,7 @@ vn-ki: 31964688+vn-ki!users.noreply.github.com, vn-ki!users.noreply.github.com
 vnagarnaik: vnagarnaik!google.com
 	Google
 vnbrs: vnbrs!icloud.com
-	Apple
+	Independent
 vnchandan: chandan.vn!samsung.com
 	Samsung
 vning93: vincent.ning93!gmail.com
@@ -6228,7 +6228,7 @@ westurner: wes.turner!gmail.com, westurner!users.noreply.github.com
 wesyao: wesyao!users.noreply.github.com
 	Microsoft
 weters: tpeters!synacor.com, weters!me.com, weters!users.noreply.github.com
-	Apple
+	Independent
 wfarnsworth: wade_farnsworth!mentor.com
 	Mentor Graphics
 wfarr: wcfarrington!gmail.com
@@ -6581,7 +6581,7 @@ wolf31o2: emertechie!gmail.com, pallawi.ds!gmail.com, wolf31o2!users.noreply.git
 	Cask Data until 2017-06-01
 	Applause from 2017-06-01
 wolfgangGoedel: wgoedel!gmail.com, wolf.goedel!me.com
-	Apple
+	Independent
 wolfgangmauerer: wolfgang.mauerer!siemens.com
 	Siemens
 wolfs: stefan.wolf.phd!gmail.com, wolf!gradle.com, wolfs!fs.tum.de
@@ -6608,7 +6608,7 @@ wongma7: mattwon!amazon.com, mawong!redhat.com, wongma7!users.noreply.github.com
 	Red Hat from 2018-06-01 until 2019-05-01
 	Amazon from 2019-05-01
 wongmjane: jane!wongmjane.com, pablo5516!gmail.com, wongmjane!icloud.com, wongmjane!users.noreply.github.com
-	Apple
+	Independent
 wonhongkwon: 522828244!qq.com, wonhongkwon!gmail.com
 	LG
 wonseop: wonseop.kim!samsung.com
@@ -6616,7 +6616,7 @@ wonseop: wonseop.kim!samsung.com
 wonzhq: wonzhq!hotmail.com, zhiqiang.wang!intel.com
 	Intel
 woodnathan: wood.nathan!me.com
-	Apple
+	Independent
 woodrow-shen: woodrow.shen!canonical.com, woodrow.shen!gmail.com
 	Canonical
 woodsaj: awoods!raintank.io, woodsaj!users.noreply.github.com
@@ -6736,7 +6736,7 @@ wu-wenxiang: wu-wenxiang!outlook.com, wu.wenxiang!99cloud.net
 wu8685: optimuswu8685!gmail.com, wu8685!users.noreply.github.com
 	vipshop
 wub: jarrod.mosen!me.com
-	Apple
+	Independent
 wudong9527: 2468406781!qq.com, wudong.lc!inspur.com, wudong9527!users.noreply.github.com
 	Inspur
 wulczer: wulczer!users.noreply.github.com, wulczer!wulczer.org
@@ -7660,7 +7660,7 @@ yguo0905: ygg!google.com, yguo0905!users.noreply.github.com
 yh06: ye.he!csr.com
 	CSR
 yhirano55: yhirano!me.com
-	Apple
+	Independent
 yhua123: yhua!vmware.com, yhua123!users.noreply.github.com
 	VMware
 yhuang-intel: ying.huang!intel.com
@@ -7798,7 +7798,7 @@ yoanisgil: gil.yoanis!gmail.com
 yoanisgil: yoanisgil!users.noreply.github.com
 	ElementAI
 yochem: yochem!icloud.com, yochem!users.noreply.github.com
-	Apple
+	Independent
 yoelcabo: yoel.cabo!gmail.com, yoelcabo!users.noreply.github.com
 	Independent until 2015-02-01
 	inLabFBI from 2015-02-01 until 2016-01-01
@@ -7839,7 +7839,7 @@ yonatanco: yonatanc!mellanox.com
 yonattanlouise: yonattan.a.louise.mendoza!linux.intel.com
 	Intel
 yonex: yonexyonex!icloud.com
-	Apple
+	Independent
 yongbok: yongbok.kim!imgtec.com
 	Independent until 2015-12-01
 	Rockplace from 2015-12-01
@@ -8098,7 +8098,7 @@ yunlzheng: marciobarbosamobile!gmail.com, yunl.zheng!gmail.com, yunl.zheng!wise2
 yunyu950908: kswarnalatha70!gmail.com, yunyu950908!gmail.com, yunyu950908!users.noreply.github.com
 	DaoCloud
 yurano: yurano!users.noreply.github.com, yuyaurano!me.com
-	Apple
+	Independent
 yuri91: y.iozzelli!gmail.com
 	Independent until 2016-06-01
 	Leaning from 2016-06-01
@@ -8129,7 +8129,7 @@ yurrriq: yurrriq!users.noreply.github.com
 	Naptaker from 2016-10-01 until 2017-11-01
 	Sportrader from 2017-11-01
 yury: yurykorolev!me.com
-	Apple
+	Independent
 yushenkuo: yushenkuo!126.com, yushenkuo!users.noreply.github.com, yushk!inspur.com
 	Inspur
 yusukeyamatani: yusukeyamatani!users.noreply.github.com
@@ -8376,7 +8376,7 @@ zdw: zdw!artisancomputer.com, zdw!cs.arizona.edu, zdw!opennetworking.org, zdw!us
 zearen: zearen.wover!gmail.com
 	Google
 zee-ahmed: zee-ahmed!users.noreply.github.com, zeieshanahmed!icloud.com
-	Apple
+	Independent
 zeerorg: r.g.gupta!outlook.com
 	Independent until 2017-02-01
 	Safety First from 2017-02-01 until 2018-02-01
@@ -8944,7 +8944,7 @@ zxiiro: 670706029!qq.com, thanh.ha!linuxfoundation.org, zxiiro!gmail.com, zxiiro
 zxjzxj521: zhangxinjie!inspur.com, zxjzxj521!users.noreply.github.com
 	Inspur
 zy475459736: drew_zhong!icloud.com, zhongyi92.work!gmail.com
-	Apple
+	Independent
 zy751713126: zhengyin!chinac.com, zhengyin!cmss.chinamobile.com
 	EasyStack until 2017-04-24
 	Chinac from 2017-04-24


### PR DESCRIPTION
This PR removes @me.com and @icloud.com registered company <> developer affiliations.

Signed-off-by: Chris Hein <me@chrishein.com>