### PR TITLE
Mark mtail as having left Google

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -326,7 +326,7 @@ geekgonecrazy: geekgonecrazy!users.noreply.github.com
 	Rocket.Chat from 2017-01-01
 geeknoid: geeknoid!users.noreply.github.com, mtail!google.com
 	Microsoft until 2014-11-01
-	Google from 2014-11-01
+	Google from 2014-11-01 until 2019-12-07
 geekodour: geekodour!users.noreply.github.com, hrishikeshbman!gmail.com
 	Independent until 2017-04-01
 	Mozilla from 2017-04-01 until 2018-12-01


### PR DESCRIPTION
Update the stats to mark @geeknoid as having left Google.

Martin, I haven't added any ongoing affiliation because I'm not sure if you contribute to Istio or any CNCF projects as part of your new role.  If you do, please feel free to update this (or comment here and I'll change the PR.)