### PR TITLE
Update affiliation

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -9518,7 +9518,8 @@ jeremymcrhat: jmcnicol!redhat.com
 	Red Hat
 jeremyrickard: jeremy.rickard!microsoft.com, jeremyrickard!users.noreply.github.com
 	VMware until 2017-11-01
-	Microsoft from 2017-11-01
+	Microsoft from 2017-11-01 until 2019-12-16
+	VMware from 2019-12-16
 jeremysuriel: jeremysuriel!users.noreply.github.com
 	Desk until 2014-08-01
 	Airtime from 2014-08-01 until 2015-08-01


### PR DESCRIPTION
Updates jeremyrickard affiliation

I left Microsoft in December 2019 and rejoined VMware. This updates my company affiliation to reflect this. 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>