### PR TITLE
vaikas/vaikas-google add vmware/gmail addresses, change github user name to match reality

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -14462,7 +14462,10 @@ vaibhavsood: vaibhavs!us.ibm.com, vaibhavsood!users.noreply.github.com
 	IBM
 vaijab: vaijab!users.noreply.github.com
 	Diet Doctor
-vaikas-google: vaikas!google.com, vaikas-google!users.noreply.github.com
+vaikas: vaikas!google.com, vaikas-google!users.noreply.github.com, vaikas!gmail.com, vaikas!vmware.com
+	Google until 2019-11-01
+	VMware from 2019-11-01
+vaikas-google: vaikas!google.com, vaikas-google!users.noreply.github.com, vaikas!gmail.com, vaikas!vmware.com
 	Google until 2019-11-01
 	VMware from 2019-11-01
 vaimo-magnus: magnus.eriksson!vaimo.com


### PR DESCRIPTION
My github username used to be vaikas-google and I changed it to just vaikas last year.  I also change to VMware last November so wanted to update my email address as well.
Does this look right?
