### PR TITLE
Update voor affiliation

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -15587,6 +15587,9 @@ vonsago: f811194414!gmail.com, vonsago!users.noreply.github.com
 	Independent
 vood: artem.vysotsky!gmail.com, vood!users.noreply.github.com
 	Connect
+voor: rcvanvo!gmail.com, voor!users.noreply.github.com
+	Pivotal until 2019-12-01
+	VMware from 2019-12-01
 vorburger: michael.vorburger+github-profile!gmail.com, mike!vorburger.ch, vorburger!google.com, vorburger!redhat.com, vorburger!users.noreply.github.com
 	Temenos until 2016-03-01
 	Red Hat from 2016-03-01 until 2019-05-01


### PR DESCRIPTION
Pivotal was acquired by VMware, updating to reflect that.

Signed-off-by: Robert Van Voorhees <rcvanvo@gmail.com>