### PR TITLE
Added vmware email

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -9526,7 +9526,7 @@ jeremyjjbrown: jeremy!tenfourty.com, jeremyjjbrown!users.noreply.github.com
 	Red Hat
 jeremymcrhat: jmcnicol!redhat.com
 	Red Hat
-jeremyrickard: jeremy.rickard!microsoft.com, jeremyrickard!users.noreply.github.com
+jeremyrickard: jeremy.rickard!microsoft.com, jeremyrickard!users.noreply.github.com, rickardj!vmware.com 
 	VMware until 2017-11-01
 	Microsoft from 2017-11-01 until 2019-12-16
 	VMware from 2019-12-16


### PR DESCRIPTION
I forgot to add my new vmware email when I updated my affiliation 🤦 

This PR adds my vmware email. 

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>