### PR TITLE
Rename Abd4llA to devguyio

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -296,7 +296,7 @@ AasthaGupta: aastha.gupta4104!gmail.com
 	Independent until 2017-12-01
 	Zulip from 2017-12-01 until 2018-03-01
 	Intuit from 2018-03-01
-Abd4llA: Abd4llA!users.noreply.github.com, aabdelre!redhat.com, ahmed.abdalla!sap.com, eng.a.abdalla!gmail.com
+devguyio: devguyio!users.noreply.github.com, aabdelre!redhat.com, ahmed.abdalla!sap.com, eng.a.abdalla!gmail.com
 	SAP until 2020-04-30
 	Red Hat from 2020-04-30
 Abdelsalam-Abbas: Abdelsalam-Abbas!users.noreply.github.com, abdelsalam.naeim!gmail.com, abdelsalam50!gmail.com


### PR DESCRIPTION
I changed my GitHub username from Abd4llA to devguyio. 

Maybe my last PR #375 is proof of me owning the old username since I updated my old Abd4llA employer details in that one. 