### PR TITLE
add sbernheim

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -8937,6 +8937,9 @@ sbelair2: sbelair!cisco.com, sbelair2!users.noreply.github.com
 	Cisco
 sbellem: sbellem!gmail.com, sbellem!users.noreply.github.com, sylvain!ascribe.io
 	ascribe
+sbernheim: sebastian!weave.works, sbernheim!users.noreply.github.com
+        Independent until 2019-05-20
+        Weaveworks from 2019-05-20
 sbevington: sabevington!lifesouth.org, sbevington!users.noreply.github.com
 	LifeSouth
 sbezverk: sbezverk!cisco.com, sbezverk!users.noreply.github.com


### PR DESCRIPTION
Add email address mapping for GitHub user sbernheim to company Weaveworks.