### PR TITLE
Rebrand Loodse to Kubermatic

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -12320,7 +12320,7 @@ alvaroaleman: alv2412!googlemail.com, alvaroaleman!users.noreply.github.com
 	Silpion from 2015-01-01 until 2017-04-01
 	inovex from 2017-04-01 until 2017-09-01
 	Deposit from 2017-09-01 until 2018-01-01
-	Loodse from 2018-01-01
+	Kubermatic from 2018-01-01
 alvarolobato: alvarolobato!gmail.com
 	Abengoa until 2016-03-01
 	CloudBees from 2016-03-01 until 2018-02-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -4582,7 +4582,7 @@ flojon: flojon!users.noreply.github.com, jonas!floden.nu
 floreks: floreks!users.noreply.github.com, madewokherd!gmail.com, s.florek91!gmail.com, sebastian.florek!loodse.com, sebastian.florek!ts.fujitsu.com
 	Transition Technologies until 2015-04-15
 	Fujitsu from 2015-04-15 until 2018-11-01
-	Loodse from 2018-11-01
+	Kubermatic from 2018-11-01
 florent-vial: florent.vial!intel.com
 	Intel
 florianb: florian.breisch!mindkeeper.solutions, florianb!users.noreply.github.com
@@ -10117,7 +10117,7 @@ infinitydon: infinitydon!users.noreply.github.com
 	Ericsson until 2017-11-01
 	Independent from 2017-11-01 until 2018-01-01
 	Cloudssky from 2018-01-01 until 2019-06-01
-	Loodse from 2019-06-01
+	Kubermatic from 2019-06-01
 infrastation: denis!ovsienko.info, infrastation!yandex.ru
 	Yandex until 2014-04-01
 	Custodian Data Centres | Data Centre & Network from 2014-04-01
@@ -16353,7 +16353,7 @@ kdomanski: github!domanski.co, kamil!domanski.co, kdomanski!kdemail.net, kdomans
 	Ingrifo from 2014-10-01 until 2015-06-01
 	Protonet from 2015-06-01 until 2017-03-01
 	Freiheit from 2017-03-01 until 2018-02-01
-	Loodse from 2018-02-01
+	Kubermatic from 2018-02-01
 kdombeck: kdombeck!users.noreply.github.com, ken.dombeck!target.com
 	Target
 kdubkris: kdubkris!users.noreply.github.com
@@ -20696,7 +20696,7 @@ maci0: maci.stgn!gmail.com, maci0!users.noreply.github.com
 maciaszczykm: m9k.tech!gmail.com, maciaszczykm!icloud.com, maciaszczykm!users.noreply.github.com, marcin.maciaszczyk!ts.fujitsu.com
 	Transition Technologies until 2015-06-15
 	Fujitsu from 2015-06-15 until 2018-09-01
-	Loodse from 2018-09-01
+	Kubermatic from 2018-09-01
 maciej: maciej.bilas!gmail.com
 	CloudFlare
 maciejgrzybek: maciejgrzybek!users.noreply.github.com
@@ -23430,7 +23430,7 @@ mfpierre: mfpierre!gmail.com, mfpierre!users.noreply.github.com
 mfranczy: mfranczy!redhat.com, mfranczy!users.noreply.github.com
 	Akamai Technologies until 2017-04-01
 	Red Hat from 2017-04-01 until 2019-10-01
-	Loodse from 2019-10-01
+	Kubermatic from 2019-10-01
 mfriedenhagen: mfriedenhagen!gmail.com, mirko.friedenhagen!1und1.de
 	United Internet AG until 2014-05-01
 	1&1 Mail & Media Applications SE from 2014-05-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -17,7 +17,7 @@ mr-yaky: mr-yaky!users.noreply.github.com
 mrIncompetent: henrik!henrik-schmidt.de, henrik!loodse.com, mrIncompetent!users.noreply.github.com
 	trigonon until 2015-08-01
 	AboutYou from 2015-08-01 until 2016-10-01
-	Loodse from 2016-10-01 until 2019-09-01
+	Kubermatic from 2016-10-01 until 2019-09-01
 	Confluent from 2019-09-01
 mracter: mracter!users.noreply.github.com
 	Praekelt
@@ -1962,7 +1962,7 @@ nikhita: hello!nikhita.dev, nikhita!users.noreply.github.com, nikitaraghunath!gm
 	Independent until 2017-12-01
 	Red Hat from 2017-12-01 until 2018-06-01
 	Independent from 2018-06-01 until 2018-10-01
-	Loodse from 2018-10-01 until 2020-04-01
+	Kubermatic from 2018-10-01 until 2020-04-01
 	VMware from 2020-04-01
 nikicat: devel.niks!gmail.com, nbryskin!yandex-team.ru
 	Yandex
@@ -3855,7 +3855,7 @@ p-steuer: patrick.steuer!de.ibm.com
 p0lyn0mial: lukasz.szaszkiewicz!gmail.com, p0lyn0mial!users.noreply.github.com
 	Intel until 2014-12-01
 	Adtoma from 2014-12-01 until 2018-01-01
-	Loodse from 2018-01-01
+	Kubermatic from 2018-01-01
 p16: filippo.desantis!gmail.com, p16!users.noreply.github.com
 	Namshi.com
 p4charu: 44200869+p4charu!users.noreply.github.com, cbopardikar!perforce.com
@@ -7922,7 +7922,7 @@ real-cost: real.cost.info!gmail.com
 realdimas: realdimas!users.noreply.github.com
 	Independent
 realfake: luk.burchard!gmail.com, realfake!users.noreply.github.com
-	Loodse
+	Kubermatic
 realityking: me!rouvenwessling.de, realityking!users.noreply.github.com, rouven!contentful.com
 	keenlogics until 2015-10-01
 	Contentful from 2015-10-01
@@ -11254,7 +11254,7 @@ schatekar: schatekar!users.noreply.github.com, suhas.chatekar!gmail.com
 	Accenture from 2015-01-01 until 2015-09-01
 	Collinson from 2015-09-01
 scheeles: scheele.s!web.de, scheeles!loodse.com, scheeles!users.noreply.github.com, sebastian!loodse.com
-	Loodse
+	Kubermatic
 schen1: sylvain.chen1!gmail.com
 	Search Initiatives until 2015-08-01
 	Margo from 2015-08-01 until 2016-02-01
@@ -22860,7 +22860,7 @@ xmudrii: mudrinic.mare!gmail.com, xmudrii!users.noreply.github.com
 	Independent until 2017-01-01
 	DigitalOcean from 2017-01-01 until 2018-04-01
 	Google from 2018-04-01 until 2018-08-01
-	Loodse from 2018-08-01
+	Kubermatic from 2018-08-01
 xmulligan: pba_32!msn.com, xmulligan!users.noreply.github.com
 	Independent until 2017-11-01
 	RiseML from 2017-11-01 until 2018-06-01
@@ -22911,7 +22911,7 @@ xroche: roche!httrack.com
 xrow: xrow!users.noreply.github.com
 	xrow
 xrstf: xrstf!users.noreply.github.com
-	Loodse
+	Kubermatic
 xscript: kevinzha!microsoft.com, kvn.zhl!gmail.com
 	Microsoft
 xsellier: xsellier!gmail.com, xsellier!users.noreply.github.com
@@ -24953,7 +24953,7 @@ zregvart: zoran!regvart.com, zregvart!apache.org, zregvart!users.noreply.github.
 zreigz: lukasz.zajaczkowski!ts.fujitsu.com, zreigz!gmail.com, zreigz!users.noreply.github.com
 	Samsung until 2015-04-15
 	Fujitsu from 2015-04-15 until 2018-11-01
-	Loodse from 2018-11-01
+	Kubermatic from 2018-11-01
 zrob: zach.robinson!gmail.com, zrob!users.noreply.github.com
 	Pivotal
 zroubalik: zroubalik!users.noreply.github.com


### PR DESCRIPTION
Loodse was rebranded to Kubermatic in May