### PR TITLE
Add dev4 and co5 into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the Cloud Native Computing Foundation's fork of Jon Corbet and Greg KH's [gitdm](https://lwn.net/Articles/290957/) tool for calculating contributions based on developers and their companies. Companies and developers can check if they are correctly attributed at the following links:
 
-Company Developers list: [co1], [co2], [co3], [co4].
+Company Developers list: [co1], [co2], [co3], [co4], [co5].
 
-Developers affiliations list: [dev1], [dev2], [dev3].
+Developers affiliations list: [dev1], [dev2], [dev3], [dev4].
 
 New affiliations are imported into DevStats about 1-2 times/month.
 
@@ -16,9 +16,9 @@ This repository is used as a source of affiliations for all [DevStats projects](
 
 If you find any errors or missing affiliations in those lists, please submit a pull request with edits to developers affiliations files: [dev1], [dev2], [dev3].
 
-Only the Developers affiliations list [dev1], [dev2], [dev3] should be edited manually.
+Only the Developers affiliations list [dev1], [dev2], [dev3], [dev4] should be edited manually.
 
-Company Developers lists [co1], [co2], [co3], [co4] are computed derivatives of the first list.
+Company Developers lists [co1], [co2], [co3], [co4], [co5] are computed derivatives of the first list.
 
 Other files used for affiliations are [email map file](https://github.com/cncf/gitdm/blob/master/src/cncf-config/email-map) and [github users](https://github.com/cncf/gitdm/blob/master/src/github_users.json) file.
 
@@ -373,7 +373,9 @@ Please follow the instructions from [ADD_PROJECT.md](https://github.com/cncf/git
 [dev1]: https://github.com/cncf/gitdm/blob/master/developers_affiliations1.txt
 [dev2]: https://github.com/cncf/gitdm/blob/master/developers_affiliations2.txt
 [dev3]: https://github.com/cncf/gitdm/blob/master/developers_affiliations3.txt
+[dev4]: https://github.com/cncf/gitdm/blob/master/developers_affiliations4.txt
 [co1]: https://github.com/cncf/gitdm/blob/master/company_developers1.txt
 [co2]: https://github.com/cncf/gitdm/blob/master/company_developers2.txt 
 [co3]: https://github.com/cncf/gitdm/blob/master/company_developers3.txt 
 [co4]: https://github.com/cncf/gitdm/blob/master/company_developers4.txt
+[co5]: https://github.com/cncf/gitdm/blob/master/company_developers5.txt


### PR DESCRIPTION
dev4 and co5 were added into README.

This is related to the issue#457
https://github.com/cncf/gitdm/issues/457