### PR TITLE
update andrewhsu affiliation

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -13179,9 +13179,10 @@ andrewharp: andrew.harp!gmail.com, andrewharp!users.noreply.github.com
 	Google
 andrewhowdencom: andrewhowdencom!users.noreply.github.com, hello!andrewhowden.com
 	Voodoo artisan
-andrewhsu: andrewhsu!acm.org, andrewhsu!docker.com, andrewhsu!users.noreply.github.com
+andrewhsu: xuzuan!gmail.com, andrewhsu!users.noreply.github.com
 	Yahoo until 2016-09-01
-	Docker from 2016-09-01
+	Docker from 2016-09-01 until 2020-02-04
+	Lightstep from 2020-02-04
 andrewjamesmorgan: andrewjamesmorgan!gmail.com, andrewjamesmorgan!users.noreply.github.com
 	MongoDB
 andrewjjenkins: andrew!aspenmesh.io, andrewjjenkins!gmail.com, andrewjjenkins!users.noreply.github.com


### PR DESCRIPTION
Updated email and company dates.

Signed-off-by: Andrew Hsu <xuzuan@gmail.com>