### PR TITLE
Update affiliation for detiber

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -777,11 +777,11 @@ detfis: detfis!gmail.com
 	Skimlinks from 2014-08-01 until 2016-04-01
 	Upnext from 2016-04-01 until 2017-02-01
 	Fresha from 2017-02-01
-detiber: detiber!gmail.com, detiber!users.noreply.github.com, detiberusj!vmware.com, jason!heptio.com, jdetiberus!packet.com
+detiber: detiber!gmail.com, detiber!users.noreply.github.com, detiberusj!vmware.com, jason!heptio.com, jdetiberus!packet.com, jdetiberus!equinix.com
 	Red Hat until 2018-01-29
 	Heptio from 2018-01-29 until 2018-12-11
 	VMware from 2018-12-11 until 2020-08-10
-	Packet from 2020-08-10
+	Equinix from 2020-08-10
 dettervt: dettervt!gmail.com, dettervt!users.noreply.github.com
 	Cisco
 deustis: deustis!users.noreply.github.com


### PR DESCRIPTION
Updating to address the recent branding change related to the Packet/Equinix acquisition.