### PR TITLE
update company name LightStep to Lightstep

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4973,7 +4973,7 @@ JulianGriggs: JulianGriggs!users.noreply.github.com, jgriggs!lightstep.com
 	Bertman Capital until 2014-08-01
 	Independent from 2014-08-01 until 2015-09-01
 	Course Hero from 2015-09-01 until 2017-09-01
-	LightStep from 2017-09-01
+	Lightstep from 2017-09-01
 JulienBalestra: JulienBalestra!users.noreply.github.com, julien.balestra!blablacar.com, julien.balestra!datadoghq.com, julien.balestra!gmail.com
 	Independent until 2016-10-01
 	BlaBlaCar from 2016-10-01 until 2017-11-01
@@ -6337,7 +6337,7 @@ MikeCongdon1: MikeCongdon1!users.noreply.github.com
 MikeGoldsmith: MikeGoldsmith!users.noreply.github.com, goldsmith.mike!gmail.com, mike!honeycomb.io
 	SaleCycle until 2016-09-01
 	Couchbase from 2016-09-01 until 2019-10-01
-	LightStep from 2019-10-01 until 2020-05-01
+	Lightstep from 2019-10-01 until 2020-05-01
 	Independent from 2020-05-01 until 2020-06-26
 	Honeycomb from 2020-06-26
 MikeJeffrey: mike.jeffrey!gmail.com, mikejeffrey!users.noreply.github.com
@@ -15616,7 +15616,7 @@ arxcruz: apcruz!br.ibm.com
 arya: arya!users.noreply.github.com
 	Twitter until 2015-02-01
 	Mixpanel from 2015-02-01 until 2017-10-01
-	LightStep from 2017-10-01
+	Lightstep from 2017-10-01
 aryabinin: a.ryabinin!samsung.com
 	Samsung
 aryabinin: aryabinin!virtuozzo.com
@@ -16334,7 +16334,7 @@ austincunningham: austincunningham!users.noreply.github.com
 austinlparker: austin!lightstep.com, austinlparker!gmail.com, austinlparker!users.noreply.github.com
 	Independent until 2014-12-01
 	Apprenda from 2014-12-01 until 2018-08-01
-	LightStep from 2018-08-01
+	Lightstep from 2018-08-01
 austinmoore-: austin.moore!teamaol.com, austin_moore!icloud.com, austinmoore-!users.noreply.github.com
 	CapTech until 2015-07-01
 	WebAssign from 2015-07-01
@@ -16705,7 +16705,7 @@ azimman: azimman!gmail.com, azimman!users.noreply.github.com
 	VMware until 2014-07-01
 	GitHub from 2014-07-01 until 2015-08-01
 	SignalFx from 2015-08-01 until 2016-05-01
-	LightStep from 2016-05-01 until 2017-06-01
+	Lightstep from 2016-05-01 until 2017-06-01
 	LaunchDarkly from 2017-06-01
 azmelanar: azmelanar!users.noreply.github.com, dslupytskyi!gmail.com
 	Hostopia until 2014-04-01
@@ -17300,7 +17300,7 @@ bcrl: bcrl!kvack.org
 bcrochet: brad!redhat.com
 	Red Hat
 bcronin: bcronin!resonancelabs.com, bcronin!users.noreply.github.com
-	LightStep
+	Lightstep
 bcwaldon: bcwaldon!gmail.com, bcwaldon!users.noreply.github.com
 	Rackspace until 2012-07-20
 	Nebula from 2012-07-20 until 2013-11-01
@@ -17624,7 +17624,7 @@ benschwarz: benschwarz!users.noreply.github.com
 	Calibre Analytics
 bensigelman: bensigelman!users.noreply.github.com
 	Code for America until 2015-01-01
-	LightStep from 2015-01-01
+	Lightstep from 2015-01-01
 bensojona: bensojon!gmail.com
 	Hashicorp
 bensussman: bensussman!users.noreply.github.com
@@ -17815,7 +17815,7 @@ bg-chun: bg-chun!users.noreply.github.com
 bg451: bg!lightstep.com, bg451!users.noreply.github.com, brandon.gonzalez.451!gmail.com
 	Larson Automation until 2014-08-01
 	Iron.io from 2014-08-01 until 2015-09-01
-	LightStep from 2015-09-01
+	Lightstep from 2015-09-01
 bgagnon: bgagnon!users.noreply.github.com
 	Ubisoft
 bgamari: ben!smart-cactus.org, bgamari.foss!gmail.com
@@ -17952,7 +17952,7 @@ bhperry: bhperry!users.noreply.github.com
 bhs: bhs!lightstep.com, bhs!resonancelabs.com, bhs!users.noreply.github.com
 	Code for America until 2015-01-01
 	Librato from 2015-01-01 until 2015-02-01
-	LightStep from 2015-02-01
+	Lightstep from 2015-02-01
 bhudlemeyer: bhudlemeyer!gmail.com
 	Dell EMC until 2016-02-01
 	Virtustream from 2016-02-01 until 2018-02-01
@@ -20312,7 +20312,7 @@ carlos-montiers: cmontiers!gmail.com
 carlosalberto: calberto.cortez!gmail.com, carlosalberto!users.noreply.github.com
 	Senzari until 2016-06-01
 	Toptal from 2016-06-01 until 2018-10-01
-	LightStep from 2018-10-01
+	Lightstep from 2018-10-01
 carlosedp: carlosedp!users.noreply.github.com, me!carlosedp.com, pracutiar!ribhararn.us
 	TIM Brasil until 2017-07-01
 	Ericsson from 2017-07-01 until 2018-08-01
@@ -22592,7 +22592,7 @@ codeblooded: codeblooded!users.noreply.github.com
 	IBM from 2016-05-01 until 2016-08-01
 	Independent from 2016-08-01
 codeboten: alrex.boten!gmail.com, codeboten!users.noreply.github.com
-	LightStep
+	Lightstep
 codecalm: 1282324+codecalm!users.noreply.github.com, codecalm!gmail.com, codecalm!users.noreply.github.com
 	84kids until 2015-11-01
 	Buddy from 2015-11-01 until 2018-06-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -12419,7 +12419,7 @@ iredelmeier: iredelmeier!gmail.com, iredelmeier!users.noreply.github.com
 	Pivotal from 2014-07-01 until 2016-01-01
 	Flux from 2016-01-01 until 2016-08-01
 	Pivotal from 2016-08-01 until 2018-09-01
-	LightStep from 2018-09-01
+	Lightstep from 2018-09-01
 iredwards: iredwards!users.noreply.github.com, red!treesandclouds.net
 	Aquent
 iremmats: iremmats!users.noreply.github.com
@@ -15700,7 +15700,7 @@ jmMeessen: jean-marc!meessen-web.org
 	CloudBees from 2016-12-01
 jmacd: jmacd!lightstep.com, jmacd!users.noreply.github.com, josh.macdonald!gmail.com
 	Google until 2016-02-15
-	LightStep from 2016-02-15
+	Lightstep from 2016-02-15
 jmagnusson: jmagnusson!users.noreply.github.com, m!jacobian.se
 	VirtecoAB until 2014-10-01
 	Hestra Gloves from 2014-10-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -3646,7 +3646,7 @@ mwc2019: chip.boling!adtran.com
 mwear: matthew.wear!gmail.com, mwear!users.noreply.github.com
 	Independent until 2015-01-01
 	New Relic from 2015-01-01 until 2019-09-27
-	LightStep from 2019-09-27
+	Lightstep from 2019-09-27
 mweibel: michael.weibel!gmail.com, mweibel!users.noreply.github.com
 	Mila until 2014-12-01
 	CENTRALWAY from 2014-12-01 until 2015-10-01
@@ -8692,7 +8692,7 @@ pitr: me!pitr.ca, pitr!users.noreply.github.com
 	Uken Games until 2014-12-01
 	Zynga from 2014-12-01
 piu28: piu28!users.noreply.github.com, pritianka!gmail.com
-	LightStep
+	Lightstep
 pivanof: pivanof!google.com, pivanof!users.noreply.github.com
 	Google
 pivanof-bot: pivanof!google.com
@@ -9553,7 +9553,7 @@ priteau: priteau!gmail.com, priteau!uchicago.edu
 pritha-srivastava: prsrivas!redhat.com
 	Red Hat
 pritianka: pritianka!gmail.com, pritianka!users.noreply.github.com
-	LightStep
+	Lightstep
 pritidesai: pdesai!us.ibm.com
 	Symantec until 2015-08-28
 	IBM from 2015-08-28
@@ -20328,7 +20328,7 @@ tedpennings: tedpennings!gmail.com, tedpennings!users.noreply.github.com, tpenni
 tedsuo: ted!lightstep.com, tedsuo!users.noreply.github.com
 	Pivotal until 2016-10-01
 	Independent from 2016-10-01 until 2017-01-01
-	LightStep from 2017-01-01
+	Lightstep from 2017-01-01
 tedwon: atp!openerp.com, jwon!redhat.com
 	Red Hat
 tedyu: tedyu!users.noreply.github.com, yuzhihong!gmail.com


### PR DESCRIPTION
Update company name LightStep to Lightstep. The proper capitalization is Lightstep. See https://lightstep.com/

There is a mixture of capitalization uses in the developers_affiliations text files and this is causing a split of numbers reported in the [devstats companies table](https://opentelemetry.devstats.cncf.io/d/5/companies-table?orgId=1).