### PR TITLE
Moving all Racher Labs people to SUSE

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4882,7 +4882,8 @@ JaroslavTulach: jaroslav.tulach!oracle.com
 JarreyZhou: 30723592+jarreyzhou!users.noreply.github.com, JarreyZhou!users.noreply.github.com, zhoujiawei7!huawei.com
 	Huawei
 Jason-ZW: Jason-ZW!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 JasonCrease: jason.crease!red-gate.com
 	Redgate until 2016-06-01
 	Featurespace from 2016-06-01
@@ -4913,7 +4914,8 @@ Jasonkuangxl: xu-liang.kuang!hpe.com
 	HP
 JasonvanBrackel: JasonvanBrackel!users.noreply.github.com, jason!vanbrackel.net
 	Apprenda until 2018-04-01
-	Rancher Labs from 2018-04-01
+	Rancher Labs from 2018-04-01 until 2020-12-01
+	SUSE from 2020-12-01
 Jasper-M: Jasper-M!users.noreply.github.com, jaspermoeys!hotmail.com
 	KU Leuven until 2017-09-01
 	Cegeka from 2017-09-01
@@ -7154,7 +7156,8 @@ Montana: Montana!users.noreply.github.com, montana!linux.com, montanamendy!gmail
 MonzElmasry: MonzElmasry!users.noreply.github.com
 	SquareConnections until 2015-03-01
 	Independent from 2015-03-01 until 2020-05-01
-	Rancher Labs from 2020-05-01
+	Rancher Labs from 2020-05-01 until 2020-12-01
+	SUSE from 2020-12-01
 MorganBauer: MorganBauer!users.noreply.github.com, mbauer!us.ibm.com
 	Lenovo until 2015-06-01
 	IBM from 2015-06-01
@@ -7705,7 +7708,8 @@ Oanerer: Oanerer!users.noreply.github.com
 Oats87: Oats87!users.noreply.github.com
 	Independent until 2017-06-01
 	Red Hat from 2017-06-01 until 2018-07-01
-	Rancher Labs from 2018-07-01
+	Rancher Labs from 2018-07-01 until 2020-12-01
+	SUSE from 2020-12-01
 Oberon00: Oberon00!users.noreply.github.com, christian.neumueller!dynatrace.com
 	Dynatrace
 OberonMin: 2324582555!qq.com, OberonMin!users.noreply.github.com, minrui01!inspur.com
@@ -9453,7 +9457,8 @@ ShylajaDevadiga: ShylajaDevadiga!users.noreply.github.com
 	Independent until 2016-12-01
 	AnchorFree from 2016-12-01 until 2018-09-01
 	WhiteHat from 2018-09-01 until 2019-09-01
-	Rancher Labs from 2019-09-01
+	Rancher Labs from 2019-09-01 until 2020-12-01
+	SUSE from 2020-12-01
 SiarheiDubovik: siarhei_dubovik!epam.com
 	EPAM
 Sicaine: Sicaine!users.noreply.github.com
@@ -9792,7 +9797,8 @@ Strech: Strech!users.noreply.github.com, oni.strech!gmail.com
 	distribusion
 StrongMonkey: strongmonkey!users.noreply.github.com
 	Independent until 2016-07-01
-	Rancher Labs from 2016-07-01
+	Rancher Labs from 2016-07-01 until 2020-12-01
+	SUSE from 2020-12-01
 StuartHarris: StuartHarris!users.noreply.github.com, stuart.harris!red-badger.com
 	Red Badger
 StudyNick: StudyNick!users.noreply.github.com, wei.chuanhui1!zte.com.cn
@@ -20131,7 +20137,8 @@ bmdepesa: bmdepesa!users.noreply.github.com
 	TEKsystems from 2015-12-01 until 2017-05-01
 	PDS from 2017-05-01 until 2017-12-01
 	American Airlines from 2017-12-01 until 2018-04-01
-	Rancher Labs from 2018-04-01
+	Rancher Labs from 2018-04-01 until 2020-12-01
+	SUSE from 2020-12-01
 bmdhacks: bdegenhardt!twitter.com
 	Twitter
 bmeekhof: bmeekhof!users.noreply.github.com
@@ -20317,7 +20324,8 @@ boingram: bo!boingram.com, boingram!users.noreply.github.com, boingram6!gmail.co
 boknowswiki: bo.tao!rancher.com
 	Fortinet until 2016-06-01
 	Palo Alto Networks from 2016-06-01 until 2020-05-01
-	Rancher Labs from 2020-05-01
+	Rancher Labs from 2020-05-01 until 2020-12-01
+	SUSE from 2020-12-01
 bokowski: bokowski!users.noreply.github.com
 	Google
 bolandro: ross.boland!hpe.com
@@ -20682,7 +20690,8 @@ brandoncole: brandon.cole!oqton.com, brandon.w.cole!gmail.com, brandoncole!users
 brandoncox: brandon.cox.519!gmail.com, brandoncox!users.noreply.github.com
 	Red Hat
 brandond: aram.koch!gmail.com, brad!oatmail.org, brandond!users.noreply.github.com, i!hyurl.com, tphpfr!gmail.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 brandondr96: brandondr96!gmail.com, brandondr96!users.noreply.github.com
 	Independent until 2018-05-01
 	IBM from 2018-05-01
@@ -20874,7 +20883,8 @@ briandowns: brian.downs!gmail.com, briandowns!users.noreply.github.com
 	Myndshft from 2018-09-01 until 2018-10-01
 	Myndshft from 2018-10-01 until 2019-09-01
 	Couchbase from 2019-09-01 until 2020-03-01
-	Rancher Labs from 2020-03-01
+	Rancher Labs from 2020-03-01 until 2020-12-01
+	SUSE from 2020-12-01
 brianduff: bduff!google.com, cairndubh!gmail.com
 	Google
 brianharwell: brianharwell!users.noreply.github.com
@@ -22186,7 +22196,8 @@ catchups: catchups!users.noreply.github.com, hyucksu.jang!samsung.com, narraba2!
 	Samsung SDS
 catherineluse: catherine.luse!gmail.com
 	Independent until 2019-06-01
-	Rancher Labs from 2019-06-01
+	Rancher Labs from 2019-06-01 until 2020-12-01
+	SUSE from 2020-12-01
 catherinetcai: catherinec!fair.com, catherinetcai!gmail.com, catherinetcai!users.noreply.github.com
 	Fair
 cathyhongzhang: cathy.h.zhang!huawei.com, cathyhongzhang!users.noreply.github.com, hzhang!futurewei.com
@@ -23901,7 +23912,8 @@ cjdcordeiro: cjdcordeiro!users.noreply.github.com
 cjdrake: cjdrake!gmail.com, cjdrake!users.noreply.github.com
 	Google
 cjellick: cjellick!users.noreply.github.com, craig!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 cjerdonek: chris.jerdonek!gmail.com
 	Independent
 cjheppell: chris.heppell!red-gate.com, chris.john.heppell!gmail.com, cjheppell!users.noreply.github.com
@@ -24184,7 +24196,8 @@ cloudever: cloudever!users.noreply.github.com
 cloudmelon: cloudmelon!users.noreply.github.com, urinaway!gmail.com
 	Microsoft
 cloudnautique: cloudnautique!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 cloudnull: cloudnull!users.noreply.github.com, kevin.carter!rackspace.com
 	Rackspace
 clrbuilder: clrbuilder!users.noreply.github.com, david.j.klimesh!intel.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -1736,7 +1736,8 @@ davidmontoyago: davidmontoyago!users.noreply.github.com
 	Expel from 2020-03-01
 davidnuzik: davidnuzik!users.noreply.github.com
 	Independent until 2018-11-01
-	Rancher Labs from 2018-11-01
+	Rancher Labs from 2018-11-01 until 2020-12-01
+	SUSE from 2020-12-01
 davido: david!ostrovsky.org, davido!users.noreply.github.com
 	Sela Group until 2014-12-01
 	Couchbase from 2014-12-01 until 2018-01-01
@@ -4030,7 +4031,8 @@ dnoe: dnoe!users.noreply.github.com, dpn!google.com
 	SpeedyPackets until 2016-11-01
 	Google from 2016-11-01
 dnoland1: dnoland!rancher.com, dnoland1!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 dnoliver: dnoliver!users.noreply.github.com, shaoshuai438!qq.com
 	Intel
 dnorris-or: david.norris!intel.com
@@ -4500,7 +4502,8 @@ dramich: dramich!users.noreply.github.com
 	Arrow Electronics from 2015-03-01 until 2015-11-01
 	Independent from 2015-11-01 until 2016-10-01
 	F5 from 2016-10-01 until 2018-01-01
-	Rancher Labs from 2018-01-01
+	Rancher Labs from 2018-01-01 until 2020-12-01
+	SUSE from 2020-12-01
 dramirezp: dramirezp!hp.com, dramirezp!hpe.com
 	HP
 drao9: drao9!users.noreply.github.com
@@ -4656,7 +4659,8 @@ drpaneas: drpaneas!users.noreply.github.com, soyking!outlook.com
 	SUSE until 2020-01-01
 	Red Hat from 2020-01-01
 drpebcak: drpebcak!users.noreply.github.com, tayworm!gmail.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 drpicox: david.rodenas!gmail.com, david.rodenas+github!gmail.com, drpicox!users.noreply.github.com, jared!hibou.io
 	Desigual until 2016-07-01
 	COEINF from 2016-07-01 until 2017-03-01
@@ -5213,7 +5217,8 @@ dweomer: dweomer!users.noreply.github.com
 	Forever Living Products until 2015-02-01
 	Parchment from 2015-02-01 until 2017-07-01
 	Intel from 2017-07-01 until 2019-08-01
-	Rancher Labs from 2019-08-01
+	Rancher Labs from 2019-08-01 until 2020-12-01
+	SUSE from 2020-12-01
 dwertent: dwertent!users.noreply.github.com
 	L&T until 2018-12-01
 	Cyber Armor from 2018-12-01
@@ -7021,7 +7026,8 @@ erikwilson: erikwilson!users.noreply.github.com, houskape!gmail.com
 	Octoblu until 2017-11-01
 	Independent from 2017-11-01 until 2018-06-01
 	Nextiva from 2018-06-01 until 2018-08-01
-	Rancher Labs from 2018-08-01
+	Rancher Labs from 2018-08-01 until 2020-12-01
+	SUSE from 2020-12-01
 erikzaadi: erik.zaadi!gmail.com
 	BigPanda
 erikzielke: erikzielke!hotmail.com
@@ -10485,7 +10491,8 @@ gitirabassi: giacomo!sighup.io, gitirabassi!users.noreply.github.com
 gitlabbin: brian.chen!iag.com.au, gitlabbin!users.noreply.github.com
 	Syndey IT
 gitlawr: lawrleegle!gmail.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 gitnik: gitnik!users.noreply.github.com
 	Minerals Value Service until 2016-03-01
 	Talentry from 2016-03-01
@@ -11608,7 +11615,8 @@ guaneryu: guaneryu!gmail.com
 	Red Hat until 2018-02-01
 	Alibaba from 2018-02-01
 guangbochen: guangbochen!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 guanglinlv: guanglinlv!users.noreply.github.com
 	cloud
 guangxuli: guangxuli!users.noreply.github.com, li.guangxu!zte.com.cn
@@ -14114,7 +14122,8 @@ ibrasho: ibra.sho!gmail.com, ibrasho!users.noreply.github.com, me!ibrasho.com
 ibriano: ivan.briano!intel.com
 	Intel
 ibuildthecloud: darren!rancher.com, darren.s.shepherd!gmail.com, ibuildthecloud!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 ibuziuk: ilyabuziuk!gmail.com
 	Exadel until 2016-02-01
 	Red Hat from 2016-02-01
@@ -15380,7 +15389,8 @@ izaac: jorge.izaac!gmail.com
 	Nearsoft from 2016-04-01 until 2017-03-01
 	Modus Create from 2017-03-01 until 2018-09-01
 	CSAA Insurance Group from 2018-09-01 until 2019-08-01
-	Rancher Labs from 2019-08-01
+	Rancher Labs from 2019-08-01 until 2020-12-01
+	SUSE from 2020-12-01
 izeau: izeau!users.noreply.github.com
 	Orange until 2014-09-01
 	Rednet from 2014-09-01
@@ -15783,7 +15793,8 @@ jambajaar: jambajaar!users.noreply.github.com
 	Citrix until 2015-04-01
 	Independent from 2015-04-01 until 2015-10-01
 	Wiztr from 2015-10-01 until 2017-12-01
-	Rancher Labs from 2017-12-01
+	Rancher Labs from 2017-12-01 until 2020-12-01
+	SUSE from 2020-12-01
 james-andrewsmith: james-andrewsmith!users.noreply.github.com
 	ARCHFASHION until 2018-01-01
 	Identitii from 2018-01-01
@@ -15993,7 +16004,8 @@ janaszewski: j.anaszewski!samsung.com
 jane-king: jenkins!radview.com
 	Cisco
 janeczku: janeczku!users.noreply.github.com, jasiu.79!gmail.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 janekbaraniewski: janekbaraniewski!users.noreply.github.com
 	Independent until 2015-04-01
 	Nex10 from 2015-04-01 until 2016-06-01
@@ -19610,7 +19622,8 @@ joshimoo: jmoody!sleepycoders.com
 	Microsoft from 2017-06-01 until 2017-09-01
 	Independent from 2017-09-01 until 2018-07-01
 	OpenEye from 2018-07-01 until 2020-04-01
-	Rancher Labs from 2020-04-01
+	Rancher Labs from 2020-04-01 until 2020-12-01
+	SUSE from 2020-12-01
 joshisa: joshisa!us.ibm.com, joshisa!users.noreply.github.com
 	IBM
 joshix: j!joshix.com, joshix!users.noreply.github.com
@@ -22274,7 +22287,8 @@ khushboo-rancher: khushboo-rancher!users.noreply.github.com
 	McAfee from 2017-12-01 until 2019-02-01
 	Independent from 2019-02-01 until 2019-08-01
 	HCL from 2019-08-01 until 2020-01-01
-	Rancher Labs from 2020-01-01
+	Rancher Labs from 2020-01-01 until 2020-12-01
+	SUSE from 2020-12-01
 khushmeen: khushmeen!users.noreply.github.com, khushmeensidhu!gmail.com
 	Independent until 2018-05-01
 	Atree Health from 2018-05-01 until 2018-06-01
@@ -22417,7 +22431,8 @@ kinarashah: kinara!rancher.com
 	Independent from 2015-06-01 until 2016-05-01
 	Skyhigh from 2016-05-01 until 2016-08-01
 	Independent from 2016-08-01 until 2017-07-01
-	Rancher Labs from 2017-07-01
+	Rancher Labs from 2017-07-01 until 2020-12-01
+	SUSE from 2020-12-01
 kincl: kincl!users.noreply.github.com
 	Independent
 king6cong: king6cong!gmail.com, king6cong!users.noreply.github.com
@@ -23120,7 +23135,8 @@ kozmagabor: gabo!kozmagabor.com, kozmagabor!users.noreply.github.com
 	Hortonworks from 2016-05-01 until 2017-12-01
 	Banzai Cloud from 2017-12-01
 kp6: kirill!rancher.com, kp6!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 kpauwel: kmultani728!gmail.com
 	PEAK6 Investments
 kpavel: kpavel!il.ibm.com
@@ -24592,7 +24608,8 @@ leodotcloud: leodotcloud!gmail.com, leodotcloud!users.noreply.github.com
 	Gigamon until 2015-12-01
 	Independent from 2015-12-01 until 2016-03-01
 	freeCodeCamp from 2016-03-01 until 2016-09-01
-	Rancher Labs from 2016-09-01
+	Rancher Labs from 2016-09-01 until 2020-12-01
+	SUSE from 2020-12-01
 leogomes: leogomes!users.noreply.github.com, leonardo.f.gomes!gmail.com
 	Amadeus
 leogr: leogr!users.noreply.github.com, me!leonardograsso.com
@@ -25488,7 +25505,8 @@ loganfsmyth: loganfsmyth!gmail.com, loganfsmyth!users.noreply.github.com
 	Inkling until 2017-01-01
 	Mozilla from 2017-01-01
 loganhz: logan!rancher.com, loganhz!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 loganking: logan.c.king!gmail.com, loganking!users.noreply.github.com
 	Rocket Jones until 2015-07-01
 	Galvanize from 2015-07-01 until 2017-09-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -578,7 +578,8 @@ luthermonson: luther.monson!gmail.com
 	SHE Media until 2015-06-01
 	ThisLife by Shutterfly from 2015-06-01 until 2017-11-01
 	RevolutionParts from 2017-11-01 until 2019-03-01
-	Rancher Labs from 2019-03-01
+	Rancher Labs from 2019-03-01 until 2020-12-01
+	SUSE from 2020-12-01
 lutostag: greg.luto!gmail.com, gregory.lutostanski!canonical.com
 	Canonical
 luvtechno: luvtechno!users.noreply.github.com
@@ -2471,7 +2472,8 @@ mattfarina: m.farina!samsung.com, matt!mattfarina.com, mattfarina!users.noreply.
 	HP from 2015-10-31 until 2017-06-23
 	Innovating Tomorrow from 2017-06-23 until 2017-08-15
 	Samsung SDS from 2017-08-15 until 2020-09-12
-	Rancher Labs from 2020-09-12
+	Rancher Labs from 2020-09-12 until 2020-12-01
+	SUSE from 2020-12-01
 mattfenwick: mattfenwick!users.noreply.github.com, mfenwick100!gmail.com
 	Hudl until 2016-05-01
 	Snagajob from 2016-05-01 until 2017-11-01
@@ -2646,7 +2648,8 @@ mattma: bigmabig!gmail.com, mattma!users.noreply.github.com
 mattmattox: mattmattox!users.noreply.github.com
 	Hyatt until 2016-02-01
 	IAA from 2016-02-01 until 2019-01-01
-	Rancher Labs from 2019-01-01
+	Rancher Labs from 2019-01-01 until 2020-12-01
+	SUSE from 2020-12-01
 mattmb: mattmb!users.noreply.github.com
 	Automation until 2016-07-01
 	Yelp from 2016-07-01
@@ -3642,7 +3645,8 @@ mejran: marcin!mindfulmachines.io, mejran!gmail.com, mejran!users.noreply.github
 mekka: mekka!mekka-tech.com, mekka!users.noreply.github.com
 	Google
 meldafrawi: meldafrawi!users.noreply.github.com, mohamed.eldafrawi!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 meledin: meledin!users.noreply.github.com, romeara!live.com, tkaluzny!outlook.com
 	Ericsson until 2018-05-01
 	Volvo from 2018-05-01
@@ -5638,7 +5642,8 @@ moelsayed: m.elsayed!gmail.com, moelsayed!users.noreply.github.com
 	Spirula Systems until 2015-08-01
 	Conseev from 2015-08-01 until 2016-12-01
 	Independent from 2016-12-01 until 2017-10-01
-	Rancher Labs from 2017-10-01
+	Rancher Labs from 2017-10-01 until 2020-12-01
+	SUSE from 2020-12-01
 moensch: moensch!users.noreply.github.com
 	McAfee until 2017-12-01
 	SendGrid from 2017-12-01
@@ -8625,7 +8630,8 @@ niuhp: niuhp!users.noreply.github.com, niuhp_dev!126.com
 niusmallnan: niusmallnan!gmail.com, niusmallnan!users.noreply.github.com
 	Neunn until 2016-11-01
 	Independent from 2016-11-01 until 2017-03-01
-	Rancher Labs from 2017-03-01
+	Rancher Labs from 2017-03-01 until 2020-12-01
+	SUSE from 2020-12-01
 niuzhenguo: Niu.ZGlinux!gmail.com, niuzhenguo!users.noreply.github.com
 	UnitedStack until 2014-09-14
 	Huawei from 2014-09-14
@@ -14419,7 +14425,8 @@ rancerbeta: mcchang!google.com
 	Twitch from 2017-12-01 until 2018-07-01
 	Google from 2018-07-01
 rancher-max: max!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 rancid: adrien.barilly!gmail.com, rancid!users.noreply.github.com
 	Gemalto
 randing89: randing89!gmail.com, randing89!users.noreply.github.com
@@ -18037,7 +18044,8 @@ sangaman: mcnallydp!gmail.com, sangaman!users.noreply.github.com
 	Perficient until 2018-01-01
 	Exchange Union from 2018-01-01
 sangeethah: sangeetha!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 sangupta01: sangupta!juniper.net
 	Juniper Networks
 sangwook: 123514+sangwook!users.noreply.github.com, sangwook!users.noreply.github.com
@@ -19789,7 +19797,8 @@ shemminger: stephen!networkplumber.org, sthemmin!microsoft.com
 shencanquan: shencanquan!huawei.com
 	Huawei
 sheng-liang: sheng!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 shengkaisun: shengkai.sun!gmail.com
 	Flyvision until 2014-08-01
 	Independent from 2014-08-01 until 2015-06-01
@@ -20244,7 +20253,8 @@ shundezhang: shundezhang!users.noreply.github.com
 shuo-wu: shuo!rancher.com, shuo-wu!users.noreply.github.com, shuo.wu.career!gmail.com
 	Independent until 2018-06-01
 	ByteDance from 2018-06-01 until 2018-09-01
-	Rancher Labs from 2018-09-01
+	Rancher Labs from 2018-09-01 until 2020-12-01
+	SUSE from 2020-12-01
 shuoranliu: shuoranliu!gmail.com, shuoranliu!users.noreply.github.com
 	风河软件研发（北京）有限公司 until 2014-11-01
 	北京惠祥和科技有限公司 from 2014-11-01 until 2015-09-01
@@ -21112,7 +21122,8 @@ smalldirector: smalldirector!users.noreply.github.com
 smallfish: max.zelinski!gmail.com, smallfish!users.noreply.github.com, smallfish.xy!gmail.com
 	Alibaba
 smallteeths: siye!rancher.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 sman591: MaprapuH!gmail.com, sman591!users.noreply.github.com, stuart!stuartolivera.com
 	Olivera Web
 smanpathak: smanpathak!users.noreply.github.com
@@ -23294,7 +23305,8 @@ superna9999: narmstrong!baylibre.com, superna9999!gmail.com
 	BabyLibre from 2015-08-01
 superseb: mail!superseb.nl, superseb!users.noreply.github.com
 	Xebia until 2014-04-01
-	Rancher Labs from 2014-04-01
+	Rancher Labs from 2014-04-01 until 2020-12-01
+	SUSE from 2020-12-01
 supershabam: ian!supershabam.com, supershabam!users.noreply.github.com
 	DigitalOcean
 superyyrrzz: renzeyu!microsoft.com, superyyrrzz!users.noreply.github.com
@@ -24748,7 +24760,8 @@ tfennelly: tom.fennelly!gmail.com
 tfherbert: tfherbert!users.noreply.github.com, thomasfherbert!gmail.com
 	Red Hat
 tfiduccia: tfiduccia!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 tfiskgul: carl-frederik.hallberg!ericsson.com, nightwalker85!gmail.com
 	Ericsson
 tfitch: github!tfitch.com, tfitch!chef.io, tfitch!getchef.com
@@ -24951,7 +24964,8 @@ thecodeassassin: hoogendijk09!gmail.com, stephen!tca0.nl, thecodeassassin!users.
 	Mycujoo from 2016-02-15 until 2017-01-15
 	Trafeo from 2017-01-15
 thecrazyrussian: mikhail!thecrazyrussian.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 thecrudge: 37271623+thecrudge!users.noreply.github.com, cody!crudge.io, thecrudge!users.noreply.github.com
 	Independent
 thedch: officialdanielhunter!gmail.com, thedch!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -3188,7 +3188,8 @@ vincent-pli: justdoit.pli!gmail.com, vincent-pli!users.noreply.github.com
 vincent178: vh7157!gmail.com, vincent178!users.noreply.github.com
 	GOAT Group
 vincent99: vincent!rancher.com, vincent99!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 vincentbernat: bernat!luffy.cx, vincent!bernat.ch, vincent!bernat.im
 	Blade Shadow
 vincentdass: vinca!microsoft.com
@@ -4953,7 +4954,8 @@ wjimenez5271: wjimenez5271!gmail.com, wjimenez5271!users.noreply.github.com
 	Chegg from 2015-05-01 until 2017-03-01
 	Rancher Labs from 2017-03-01 until 2017-12-01
 	Primer.ai from 2017-12-01 until 2019-03-01
-	Rancher Labs from 2019-03-01
+	Rancher Labs from 2019-03-01 until 2020-12-01
+	SUSE from 2020-12-01
 wjin: wjin!users.noreply.github.com, wjin.cn!gmail.com
 	Bytadance
 wjn740: ahmadhamza19!gmail.com, jnwang!suse.com
@@ -5594,7 +5596,8 @@ xiaolanz: xiaolan!google.com, xiaolanz!users.noreply.github.com
 xiaolou86: lzw19860818!aliyun.com, xiaolou86!users.noreply.github.com
 	Alibaba
 xiaoluhong: xiaoluhong!rancher.com, xiaoluhong!users.noreply.github.com
-	Rancher Labs
+	Rancher Labs until 2020-12-01
+	SUSE from 2020-12-01
 xiaom-GitHub: max8612!gmail.com, xiaom!google.com, xiaom-GitHub!users.noreply.github.com
 	Cisco until 2016-01-01
 	Nest from 2016-01-01 until 2017-11-01
@@ -6153,7 +6156,8 @@ yankcrime: yankcrime!users.noreply.github.com
 	DataCentred until 2017-11-01
 	StackHPC from 2017-11-01 until 2019-02-01
 	D2iQ from 2019-02-01 until 2020-04-01
-	Rancher Labs from 2020-04-01
+	Rancher Labs from 2020-04-01 until 2020-12-01
+	SUSE from 2020-12-01
 yanmarkman: ymarkman!marvell.com
 	Marvell
 yann-morin-1998: yann.morin.1998!free.fr
@@ -6288,7 +6292,8 @@ yashykt: yashkt!google.com, yashykt!gmail.com, yashykt!users.noreply.github.com
 	Google from 2017-06-01
 yasker: aldo.vizcaino87!gmail.com, sheng!yasker.org, sheng.yang!rancher.com, yasker!users.noreply.github.com
 	Citrix until 2015-01-01
-	Rancher Labs from 2015-01-01
+	Rancher Labs from 2015-01-01 until 2020-12-01
+	SUSE from 2020-12-01
 yaso195: kerim.oktay!apcera.com
 	Apcera
 yasongxu: 1154564309!qq.com, xuyasong!baidu.com, yasongxu!users.noreply.github.com


### PR DESCRIPTION
Rancher Labs was acquired by SUSE. This change moves everyone currently listed as working at Rancher Labs to SUSE. You can see the acquisition at https://rancher.com/blog/2020/suse-day1