### PR TITLE
Update company affiliation for csmarchbanks

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -2408,9 +2408,10 @@ csmanjuvijay: csmanjuvijay!gmail.com
 csmarchbanks: csmarchbanks!gmail.com, csmarchbanks!users.noreply.github.com
 	Pipeworks Software until 2014-01-01
 	Thetus Corporation from 2014-01-01 until 2015-10-01
-	Relly Software from 2015-10-01 until 2018-01-01
+	Rally Software from 2015-10-01 until 2018-01-01
 	FreshTracks.io ("CA INC") from 2018-01-01 until 2018-11-01
-	Splunk Inc. from 2018-11-01
+	Splunk Inc. from 2018-11-01 until 2021-01-01
+	Grafana Labs from 2021-01-01
 csmart: chris!distroguy.com
 	Independent until 2017-01-15
 	Rackspace from 2017-01-15


### PR DESCRIPTION
Update my company affiliation from Splunk to Grafana. Also fixes a typo in a previous company.