### PR TITLE
Update affiliation for Michał Flendrich

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -8590,8 +8590,9 @@ mfiumara: mattia.fiumara!bgridsolutions.com
 mfleming: matt!codeblueprint.co.uk, matt!console-pimps.org, matt.fleming!intel.com
 	Intel until 2015-10-01
 	SUSE LLC from 2015-10-01
-mflendrich: mflendrich!users.noreply.github.com
-	Weaveworks
+mflendrich: michal!flendrich.pro mflendrich!users.noreply.github.com
+	Weaveworks until 2020-02-01
+	Kong Inc. from 2020-06-01
 mfmooney: mfm!muteddisk.com
 	Independent
 mfocaraccio: marianof23!gmail.com, mfocaraccio!users.noreply.github.com


### PR DESCRIPTION
Signed-off-by: Michał Flendrich <michal@flendrich.pro>