### PR TITLE
Update affiliation for @evan2645 and @azdagron

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -20424,8 +20424,10 @@ azarzar15: azarzar15!users.noreply.github.com, or!lightspin.io
 azazel75: azazel75!users.noreply.github.com, hiteshkrsahu!gmail.com
 	SuaWeb until 2015-12-01
 	Independent from 2015-12-01
-azdagron: azdagron!gmail.com, azdagron!users.noreply.github.com
-	Scytale
+azdagron: aharding!vmware.com, andrew.harding!hpe.com, harding!scytale.io, azdagron!gmail.com, azdagron!users.noreply.github.com
+	Scytale until 2020-03-01
+	HPE from 2020-03-01 until 2020-08-31
+	VMware from 2020-08-31
 azell: azell!users.noreply.github.com, zellster!gmail.com
 	Uber
 azemoning: azemoning!users.noreply.github.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -11799,10 +11799,12 @@ evaldasou: evaldas.ousinskis!gmail.com, evaldasou!users.noreply.github.com
 	Independent
 evalsocket: evalsocket!users.noreply.github.com
 	Independent
-evan2645: evan!scytale.io, evan2645!gmail.com, evan2645!users.noreply.github.com
+evan2645: egilman!vmware.com, evan!hpe.com, evan!scytale.io, evan2645!gmail.com, evan2645!users.noreply.github.com
 	PagerDuty until 2017-02-01
 	Independent from 2017-02-01 until 2017-07-01
-	Scytale from 2017-07-01
+	Scytale from 2017-07-01 until 2020-03-01
+	HPE from 2020-03-01 until 2020-08-31
+	VMware from 2020-08-31
 evanches: echeshire!barefootnetworks.com
 	Independent until 2014-04-01
 	Schlumberger Limited from 2014-04-01 until 2014-08-01


### PR DESCRIPTION
This commit updates the affiliations of Evan Gilman and Andrew Harding
to reflect reality.

"Proof" available at https://github.com/spiffe/spire/blob/master/CODEOWNERS

Signed-off-by: Evan Gilman <egilman@vmware.com>