### PR TITLE
update "poiana" affiliation (robot)

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -22645,7 +22645,7 @@ pohsienshih: pohsien324!gmail.com
 	Independent until 2019-02-01
 	inwinSTACK from 2019-02-01
 poiana: 51138685+poiana!users.noreply.github.com, poiana!users.noreply.github.com
-	Falcon.io
+	(Robots)
 poiati: paulogpoiati!gmail.com, poiati!users.noreply.github.com
 	BoaConsulta until 2019-01-01
 	Dapper Labs from 2019-01-01 until 2019-09-01


### PR DESCRIPTION
Hi,

I'm a [maintainer](https://github.com/falcosecurity/.github/blob/master/maintainers.yaml#L93) of the Falco project, and I have noticed that our bot was wrongly affiliated.

@poiana is a bot used by the [falcosecurity](https://github.com/falcosecurity) GitHub organization, and it is not affiliated with "Falcon.io".

Thanks.

