### PR TITLE
Update affiliation for shysank

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -11884,11 +11884,8 @@ shyoo: shyoo!google.com, shyoo!sunghwanyoo.com
 shyr: shyr!users.noreply.github.com
 	NAVER Corp until 2020-07-01
 	Amazon from 2020-07-01
-shysank: shysank!users.noreply.github.com
-	Baryons until 2014-03-01
-	Intrigo from 2014-03-01 until 2015-09-01
-	Independent from 2015-09-01 until 2016-01-01
-	Cloudvisory from 2016-01-01
+shysank: 11148738+shysank!users.noreply.github.com
+	VMware
 si458: si458!users.noreply.github.com
 	Hestor
 si74: si74!users.noreply.github.com, sneha.inguva!gmail.com


### PR DESCRIPTION
There is already a "shysank" present which is not me. I think it could be because I recently changed my github username last year.