### PR TITLE
Fixing the GitHub user name of Joshi, Kishor

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -10613,7 +10613,7 @@ kisangdev: kisangdev!gmail.com, kisangdev!users.noreply.github.com
 	Samsung SDS
 kiseok7: kiseok7!gmail.com, kiseok7!users.noreply.github.com
 	Netmarble
-kishorj: kishorj!users.noreply.github.com
+kishorjoshi: kishorjoshi!users.noreply.github.com
 	Independent until 2016-10-01
 	Infosys from 2016-10-01 until 2018-09-01
 	Nokia from 2018-09-01


### PR DESCRIPTION
The affiliation list has the wrong user name for Joshi. The list contains
@kishorj while Joshi-s username is @kishorjoshi.

