### PR TITLE
Update Pawel Krupa (paulfantom) affiliation

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -12792,7 +12792,9 @@ paulduffin: paulduffin!google.com
 paulehoffman: paulehoffman!users.noreply.github.com, phoffman!proper.com
 	Success Creation
 paulfantom: paulfantom!gmail.com, paulfantom!redhat.com, paulfantom!users.noreply.github.com, pawel!krupa.net.pl
-	Red Hat Inc.
+	Independent until 2018-05-20
+	Red Hat Inc. from 2018-05-21 until 2021-09-31
+	Timescale Inc. from 2021-10-01
 paulfertser: drewish!katherinehouse.com, fercerpav!gmail.com
 	Geonodal Solutions
 paulgavrikov: paulgavrikov!users.noreply.github.com


### PR DESCRIPTION
Signed-off-by: Paweł Krupa pawel@krupa.net.pl

Updating via GitHub web UI. Sorry for brevity :)