### PR TITLE
Update youngnick affiliation after erroneous change

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -18346,14 +18346,9 @@ youngjoon-lee: taxihighway!gmail.com, youngjoon-lee!users.noreply.github.com
 	Independent from 2018-06-01 until 2018-11-01
 	SO1 from 2018-11-01 until 2020-07-01
 	MediBloc from 2020-07-01
-youngnick: inocuo!gmail.com, mail!dario-baumberger.ch, nyoung!atlassian.com
+youngnick: inocuo!gmail.com, nyoung!atlassian.com, ynick!vmware.com, youngnick!users.noreply.github.com
 	Atlassian Inc until 2019-05-01
 	VMware Inc. from 2019-05-01
-youngnick: ynick!vmware.com, youngnick!users.noreply.github.com
-	Naver Corporation until 2018-06-01
-	Independent from 2018-06-01 until 2018-11-01
-	SO1 from 2018-11-01 until 2020-07-01
-	MediBloc from 2020-07-01
 youngrrrr: youngrrrr!users.noreply.github.com
 	Naver Corporation until 2018-06-01
 	Independent from 2018-06-01 until 2018-11-01


### PR DESCRIPTION
Looks like at some point my developer affiliation got munged up with someone else's.

This corrects things.

Signed-off-by: Nick Young <ynick@vmware.com>