### PR TITLE
Update Adolfo García Veytia (puerco) affiliations

### DIFF
--- a/company_developers1.txt
+++ b/company_developers1.txt
@@ -15120,6 +15120,7 @@ Chainguard Inc.:
 	mattmoor: mattmoor!chainguard.dev, mattmoor!google.com, mattmoor!users.noreply.github.com from 2021-10-01
 	mattmoor-sockpuppet: 32418083+mattmoor-sockpuppet!users.noreply.github.com, mattmoor+sockpuppet!google.com from 2021-10-01
 	n3wscott: 32305648+n3wscott!users.noreply.github.com, n3wscott!chainguard.dev, nicholss!google.com from 2021-10-01
+	puerco: puerco!chainguard.dev, puerco!users.noreply.github.com
 	vaikas: vaikas!gmail.com, vaikas!google.com, vaikas!vmware.com, vaikas-google!users.noreply.github.com from 2021-10-01
 	vaikas-google: vaikas!chainguard.dev, vaikas!gmail.com, vaikas!google.com, vaikas!vmware.com, vaikas-google!users.noreply.github.com from 2021-10-01
 Chainlink:

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -21287,8 +21287,10 @@ puellanivis: puellanivis!users.noreply.github.com
 	Zattoo from 2017-03-01 until 2018-05-01
 	Independent from 2018-05-01 until 2018-06-01
 	HelloFresh from 2018-06-01
-puerco: puerco!users.noreply.github.com
-	uServers
+puerco: puerco!chainguard.dev, puerco!users.noreply.github.com
+	uServers until 2021-09-06
+	Mattermost Inc. from 2021-09-07 until 2021-12-31
+	Chainguard Inc. from 2022-01-01
 pugangxa: pugangxa!cn.ibm.com, pugangxa!users.noreply.github.com
 	International Business Machines Corporation
 puiterwijk: 26716201!qq.com, patrick!puiterwijk.org, puiterwijk!redhat.com, puiterwijk!users.noreply.github.com


### PR DESCRIPTION
Update the company affiliations from Adolfo García Veytia (GH: puerco)

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>