### PR TITLE
Update mattrobenolt developer affiliation

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -6482,8 +6482,7 @@ mattrjacobs: mattrjacobs!gmail.com, mattrjacobs!users.noreply.github.com
 	Netflix Inc. until 2017-08-01
 	Gremlin Inc. from 2017-08-01
 mattrobenolt: m!robenolt.com, matt!ydekproductions.com, mattrobenolt!users.noreply.github.com
-	YDEK Productions until 2015-09-15
-	Sentry from 2015-09-15
+	PlanetScale from 2020-03-23
 mattrope: matthew.d.roper!intel.com
 	Intel Corporation
 mattrowmsft: matt.trower!microsoft.com, mattrowmsft!users.noreply.github.com


### PR DESCRIPTION
Neither YDEK Productions or Sentry would have any relevance for CNCF contributions. I didn't contribute until working at PlanetScale.