### PR TITLE
Update name mapping for Atlassian

### DIFF
--- a/src/company-names-mapping
+++ b/src/company-names-mapping
@@ -68,6 +68,7 @@ Armory -> Armory
 Arris -> Arris
 Assurity Consulting Limited -> Assurity
 Atlassian -> Atlassian
+Atlassian Inc -> Atlassian
 Audi AG -> Audi AG
 Autodesk -> Autodesk
 Automattic -> Automattic


### PR DESCRIPTION
Atlassian is reported separately as "Atlassian" and "Atlassian Inc" in the stats. This change sets a mapping to use the preferred "Atlassian" in reports.