### PR TITLE
Update datadog affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4453,9 +4453,9 @@ ChristineTChen: ChristineTChen!users.noreply.github.com
 	Quickbase from 2017-01-01 until 2017-06-01
 	JPMorgan Chase from 2017-06-01 until 2017-08-01
 	Independent from 2017-08-01 until 2018-01-01
-	Datadog from 2018-01-01 until 2019-04-01
+	Datadog Inc from 2018-01-01 until 2019-04-01
 	Independent from 2019-04-01 until 2019-07-01
-	Datadog from 2019-07-01
+	Datadog Inc from 2019-07-01
 Christoffer-Cortes: Christoffer-Cortes!users.noreply.github.com, christoffer.cortes.sjowall!ericsson.com
 	Ericsson
 ChristofferNicklassonLenswayGroup: ChristofferNicklassonLenswayGroup!users.noreply.github.com
@@ -7873,7 +7873,7 @@ Gregcake: gregtanyy!gmail.com
 	Accenture Global Solutions Limited from 2017-11-01 until 2018-02-01
 	Independent from 2018-02-01 until 2018-10-01
 	TradeGecko from 2018-10-01 until 2020-05-01
-	Datadog from 2020-05-01
+	Datadog Inc from 2020-05-01
 Gregoirevda: greg!hackages.io, gregoirevandera!gmail.com
 	Independent
 GregorBiswanger: GregorBiswanger!users.noreply.github.com, gregor.biswanger!web-enliven.de
@@ -7938,7 +7938,7 @@ Gui774ume: Gui774ume!users.noreply.github.com
 	Independent from 2017-01-01 until 2017-06-01
 	VideoLabs from 2017-06-01 until 2017-08-01
 	Paris Digital from 2017-08-01 until 2018-02-01
-	Datadog from 2018-02-01
+	Datadog Inc from 2018-02-01
 GuilhermeCamposo: guilherme.camposo!me.com
 	The Marlo Group until 2018-01-01
 	Red Hat Inc. from 2018-01-01
@@ -8962,7 +8962,7 @@ IvanTopolcic: IvanTopolcic!users.noreply.github.com
 	Weebly from 2018-05-01 until 2018-06-01
 	Square Inc. from 2018-06-01 until 2018-09-01
 	Independent from 2018-09-01 until 2019-07-01
-	Datadog from 2019-07-01
+	Datadog Inc from 2019-07-01
 IvanVergiliev: IvanVergiliev!users.noreply.github.com, ivan.vergiliev!gmail.com
 	Leanplum
 Ivanhu5866: ivan.hu!canonical.com
@@ -10598,7 +10598,7 @@ KSerrania: KSerrania!users.noreply.github.com
 	Paris Digital from 2017-01-01 until 2017-08-01
 	Affinity Hive from 2017-08-01 until 2018-01-01
 	Independent from 2018-01-01 until 2019-05-01
-	Datadog from 2019-05-01
+	Datadog Inc from 2019-05-01
 KTan1226: KTan1226!users.noreply.github.com
 	Independent until 2014-12-01
 	CNCF from 2014-12-01 until 2019-05-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -12545,7 +12545,8 @@ binarycrayon: binarycrayon!users.noreply.github.com
 	Scenarion from 2017-09-01 until 2018-03-01
 	Kabam from 2018-03-01
 binarylogic: binarylogic!users.noreply.github.com
-	Timber.io
+	Timber.io until 2021-02-11
+        Datadog Inc from 2021-02-11
 binbinwu1: binbin.wu!intel.com, chanduveerlas93!gmail.com
 	Intel Corporation
 binchenX: binchenX!users.noreply.github.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -12546,7 +12546,7 @@ binarycrayon: binarycrayon!users.noreply.github.com
 	Kabam from 2018-03-01
 binarylogic: binarylogic!users.noreply.github.com
 	Timber.io until 2021-02-11
-        Datadog Inc from 2021-02-11
+	Datadog Inc from 2021-02-11
 binbinwu1: binbin.wu!intel.com, chanduveerlas93!gmail.com
 	Intel Corporation
 binchenX: binchenX!users.noreply.github.com

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -11364,7 +11364,7 @@ bekircanagaoglu: bekircanagaoglu!gmail.com
 belak: belak!coded.io, belak!users.noreply.github.com, isirinz!naver.com, kaleb!coded.io
 	Atlassian until 2017-04-01
 	Pokémon from 2017-04-01 until 2020-09-01
-	Datadog from 2020-09-01
+	Datadog Inc from 2020-09-01
 beldougie: beldougie!users.noreply.github.com, matt!beldougie.com, matt.keeble!gmail.com
 	Beldougie
 beli-sk: beli-sk!users.noreply.github.com, devel!beli.sk
@@ -12914,9 +12914,9 @@ bkthomps: bailey.kyle.thompson!gmail.com
 	Independent from 2018-08-01 until 2019-01-01
 	Lime from 2019-01-01 until 2019-04-01
 	Independent from 2019-04-01 until 2019-09-01
-	Datadog from 2019-09-01 until 2019-12-01
+	Datadog Inc from 2019-09-01 until 2019-12-01
 	Independent from 2019-12-01 until 2020-09-01
-	Datadog from 2020-09-01 until 2020-12-01
+	Datadog Inc from 2020-09-01 until 2020-12-01
 	Independen from 2020-12-01 until 2021-07-01
 	Pinterest Inc. from 2021-07-01
 bkuschel: bkuschel!users.noreply.github.com
@@ -15067,7 +15067,7 @@ brycekahle: bkahle!gmail.com, bryce!brycekahle.com, bryce.kahle!mlssoccer.com, b
 	Particle from 2017-04-01 until 2017-06-01
 	Netlify from 2017-06-01 until 2018-09-01
 	Trajnosurus from 2018-09-01 until 2020-05-01
-	Datadog from 2020-05-01
+	Datadog Inc from 2020-05-01
 brycethomsen: brycethomsen!users.noreply.github.com
 	Independent until 2017-06-01
 	Concur Technologies Inc from 2017-06-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -383,7 +383,7 @@ davidor: davidor!users.noreply.github.com
 	Independent until 2015-09-01
 	3scale Inc from 2015-09-01 until 2016-08-01
 	Red Hat Inc. from 2016-08-01 until 2021-07-01
-	Datadog from 2021-07-01
+	Datadog Inc from 2021-07-01
 davidovich: david.genest!gmail.com, davidovich!users.noreply.github.com
 	Ubisoft Montreal
 davidparsson: david!parsson.se
@@ -5485,7 +5485,7 @@ duarten: duarte!fastmail.com
 	ScyllaDB Ltd. from 2016-03-01 until 2019-04-01
 	vectorized from 2019-04-01 until 2019-11-01
 	Umani from 2019-11-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 dubee: dubee!users.noreply.github.com, jwdubee!us.ibm.com
 	International Business Machines Corporation
 dubek: dubek!users.noreply.github.com
@@ -13193,7 +13193,7 @@ gbaufake: gbaufake!redhat.com, gbaufake!users.noreply.github.com
 gbbr: gabriel!datadog.com, gbbr!users.noreply.github.com
 	stripetree until 2016-03-01
 	Sourcefabric from 2016-03-01 until 2017-12-01
-	Datadog from 2017-12-01
+	Datadog Inc from 2017-12-01
 gbedoya: gbedoya!users.noreply.github.com
 	Cloudflare Inc
 gbellows-linaro: greg.bellows!linaro.org
@@ -18786,7 +18786,7 @@ hosseinsia: hosseinsia!users.noreply.github.com
 	Agari Data Inc from 2017-05-01 until 2017-08-01
 	Independent from 2017-08-01 until 2019-03-01
 	Google LLC from 2019-03-01 until 2021-07-01
-	Datadog from 2021-07-01
+	Datadog Inc from 2021-07-01
 hostirosti: hostirosti!users.noreply.github.com
 	Google LLC
 hosungsmsft: hoson!microsoft.com, hosungs!live.com, hosungsmsft!users.noreply.github.com
@@ -23403,9 +23403,9 @@ jaronoff97: jaronoff97!users.noreply.github.com
 	Independent until 2015-06-01
 	BitSight Technologies Inc from 2015-06-01 until 2016-08-01
 	Independent from 2016-08-01 until 2017-05-01
-	Datadog from 2017-05-01 until 2017-08-01
+	Datadog Inc from 2017-05-01 until 2017-08-01
 	NUHacks from 2017-08-01 until 2018-01-01
-	Datadog from 2018-01-01 until 2018-07-01
+	Datadog Inc from 2018-01-01 until 2018-07-01
 	Giphy Inc. from 2018-07-01 until 2019-09-01
 	Drift from 2019-09-01 until 2021-07-01
 	LightStep Inc. from 2021-07-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -5590,7 +5590,7 @@ jszwedko: jesse!szwedko.me, jesse.szwedko!gmail.com, jszwedko!users.noreply.gith
 	Diginido from 2017-04-01 until 2017-10-01
 	City and County of San Francisco from 2017-10-01 until 2018-09-01
 	Timber.io from 2018-09-01 until 2021-02-11
-        Datadog Inc from 2021-02-11
+	Datadog Inc from 2021-02-11
 jt143: justinhuang!me.com
 	Apple Inc.
 jtaleric: joe.talerico!gmail.com, jtaleric!users.noreply.github.com
@@ -13868,7 +13868,7 @@ llivingstone: llivingstone!users.noreply.github.com
 	Curve OS Limited from 2019-09-01
 lloeki: lloeki!users.noreply.github.com, loic.nageleisen!gmail.com
 	Sqreen until 2021-04-12
-        Datadog Inc from 2021-04-12
+	Datadog Inc from 2021-04-12
 lloydde: foolswisdom!gmail.com, lloydde!users.noreply.github.com, lloydooh!gmail.com
 	Ioyent until 2015-10-01
 	Apcera from 2015-10-01 until 2016-09-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -9121,7 +9121,7 @@ kindermoumoute: kindermoumoute!users.noreply.github.com
 	Independent from 2015-07-01 until 2016-05-01
 	Intel Corporation from 2016-05-01 until 2017-01-01
 	Independent from 2017-01-01 until 2018-02-01
-	Datadog from 2018-02-01 until 2018-07-01
+	Datadog Inc from 2018-02-01 until 2018-07-01
 	Scaleway from 2018-07-01
 kinderyj: kinderyj!qq.com, kinderyj!users.noreply.github.com
 	Google LLC
@@ -9327,7 +9327,7 @@ kitfre: kitfre!users.noreply.github.com, kitfreddura!gmail.com
 	Independent from 2016-06-01 until 2016-12-01
 	The Agile Monkeys from 2016-12-01 until 2017-03-01
 	Moogsoft from 2017-03-01 until 2020-12-01
-	Datadog from 2020-12-01
+	Datadog Inc from 2020-12-01
 kitos9112: kitos9112!users.noreply.github.com
 	everis until 2014-08-01
 	Independent from 2014-08-01 until 2015-05-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -5589,7 +5589,8 @@ jszwedko: jesse!szwedko.me, jesse.szwedko!gmail.com, jszwedko!users.noreply.gith
 	Braintree Payments from 2014-12-01 until 2017-04-01
 	Diginido from 2017-04-01 until 2017-10-01
 	City and County of San Francisco from 2017-10-01 until 2018-09-01
-	Timber.io from 2018-09-01
+	Timber.io from 2018-09-01 until 2021-02-11
+        Datadog Inc from 2021-02-11
 jt143: justinhuang!me.com
 	Apple Inc.
 jtaleric: joe.talerico!gmail.com, jtaleric!users.noreply.github.com
@@ -13866,7 +13867,8 @@ llivingstone: llivingstone!users.noreply.github.com
 	Independent from 2018-08-01 until 2019-09-01
 	Curve OS Limited from 2019-09-01
 lloeki: lloeki!users.noreply.github.com, loic.nageleisen!gmail.com
-	Sqreen
+	Sqreen until 2021-04-12
+        Datadog Inc from 2021-04-12
 lloydde: foolswisdom!gmail.com, lloydde!users.noreply.github.com, lloydooh!gmail.com
 	Ioyent until 2015-10-01
 	Apcera from 2015-10-01 until 2016-09-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -2085,7 +2085,7 @@ nacho-undefinedlabs: 47814950+nacho-undefinedlabs!users.noreply.github.com, nach
 	Mirada from 2016-01-01 until 2018-03-01
 	NEORIS from 2018-03-01 until 2019-02-01
 	Undefined Labs Inc. from 2019-02-01 until 2020-07-01
-	Datadog Inc. from 2020-07-01
+	Datadog Inc from 2020-07-01
 
 nachocano: nachoacano!gmail.com, nachocano!users.noreply.github.com
 	Independent until 2015-04-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -2084,7 +2084,9 @@ nacho-undefinedlabs: 47814950+nacho-undefinedlabs!users.noreply.github.com, nach
 	Grability from 2015-12-01 until 2016-01-01
 	Mirada from 2016-01-01 until 2018-03-01
 	NEORIS from 2018-03-01 until 2019-02-01
-	Undefined from 2019-02-01
+	Undefined Labs Inc. from 2019-02-01 until 2020-07-01
+	Datadog Inc. from 2020-07-01
+
 nachocano: nachoacano!gmail.com, nachocano!users.noreply.github.com
 	Independent until 2015-04-01
 	Independent from 2015-04-01 until 2015-06-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -7464,7 +7464,7 @@ tgermain: tgermain!users.noreply.github.com, timothee.germain!wanadoo.fr
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 tghartland: tghartland!users.noreply.github.com, thomas.george.hartland!cern.ch
 	CERN
 tglstory: hyunjoon.seol!gmail.com, tglstory!users.noreply.github.com
@@ -7475,7 +7475,7 @@ tgorochowik: t!gorochowik.com
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 tgorochowik: tgorochowik!antmicro.com, tgorochowik!users.noreply.github.com
 	ANTMICRO LTD
 tgracchus: ulises.olivenza!gmail.com
@@ -7491,7 +7491,7 @@ tgraf: clintp1!gmail.com
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 tgriesser: tgriesser!gmail.com, tgriesser10!gmail.com
 	Snugg Home LLC until 2016-09-01
 	Rocketrip Inc from 2016-09-01 until 2017-12-01
@@ -7519,7 +7519,7 @@ thaJeztah: thajeztah!users.noreply.github.com
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 thabok: thabokrick!gmail.com
 	BTC Embedded
 thadc23: me!thadcraft.com
@@ -7624,14 +7624,14 @@ thbkrkr: thbkrkr!users.noreply.github.com
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 thcdrt: thomas.coudert!corp.ovh.com
 	Worldline Global until 2014-08-01
 	Independent from 2014-08-01 until 2015-04-01
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 thdotnet: thdotnet!users.noreply.github.com, thiago.custodio!hotmail.com
 	Ka Solution until 2015-08-01
 	Sciensa from 2015-08-01 until 2016-06-01
@@ -7678,7 +7678,7 @@ theRealWardo: contact!mwdesigns.com
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 theRealWardo: theRealWardo!users.noreply.github.com
 	YouTube until 2016-07-01
 	Mux from 2016-07-01
@@ -8523,7 +8523,7 @@ thwarted: github!thwartedefforts.org
 	Kelkoo Group from 2015-04-01 until 2015-09-01
 	OVH SAS from 2015-09-01 until 2018-06-01
 	LumApps from 2018-06-01 until 2021-01-01
-	Datadog from 2021-01-01
+	Datadog Inc from 2021-01-01
 thxCode: 664647065!qq.com, frank!rancher.com, thxCode!users.noreply.github.com
 	Alibaba.com
 thylong: theotime.leveque!dailymotion.com, thylong!users.noreply.github.com
@@ -12727,7 +12727,7 @@ valerian-roche: valerian-roche!users.noreply.github.com
 	Independent from 2014-09-01 until 2015-03-01
 	Carrefour from 2015-03-01 until 2015-06-01
 	Amadeus from 2015-06-01 until 2020-11-01
-	Datadog from 2020-11-01
+	Datadog Inc from 2020-11-01
 valeriano-manassero: valeriano-manassero!users.noreply.github.com
 	Area Riscossioni until 2014-12-01
 	Aruba SpA from 2014-12-01 until 2017-12-01
@@ -13086,7 +13086,7 @@ vbannai: bannai!google.com, vbannai!users.noreply.github.com
 vbarbaresi: vbarbaresi!users.noreply.github.com
 	SoftBank until 2016-07-01
 	Opendatasoft from 2016-07-01 until 2020-02-01
-	Datadog from 2020-02-01
+	Datadog Inc from 2020-02-01
 vbarrier: barrier.vincent!gmail.com, vbarrier!kagilum.com
 	Kagilum SAS
 vbathke: contato!victorbathke.eti.br
@@ -21563,7 +21563,7 @@ zhiyanfoo: zhiyanfoo!users.noreply.github.com
 	Sette from 2019-01-01 until 2019-04-01
 	Independent from 2019-04-01 until 2019-09-01
 	Tulip Interfaces from 2019-09-01 until 2019-12-01
-	Datadog from 2019-12-01
+	Datadog Inc from 2019-12-01
 zhiyelee: zhiyelee!gmail.com, zhiyelee!users.noreply.github.com
 	Meituan Dianping until 2015-03-01
 	70kft from 2015-03-01 until 2015-08-01


### PR DESCRIPTION
Clean up on various Datadog affiliations.

1. There were multiple Datadog entires (Datadog Inc vs Datadog).  This combines them.
2. There were multiple Undefined Labs entries. This combines them.  Undefined Labs was acquired by Datadog in July 2020, so this updates affiliations as well.
3. Timber was acquired in Feb 2021 by Datadog. Updates their affiliations. 