### PR TITLE
Daimler TSS renamed to MB Tech Innovation

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -21568,9 +21568,10 @@ seans3: seans!google.com, seans3!users.noreply.github.com
 seans3: seans3!gmail.com
 	Sony Interactive Entertainment LLC until 2016-08-01
 	Activision Publishing Inc. from 2016-08-01
-seanschneeweiss: sean.schneeweiss!daimler.com, seanschneeweiss!users.noreply.github.com
+seanschneeweiss: sean.schneeweiss!mercedes-benz.com, sean.schneeweiss!daimler.com, seanschneeweiss!users.noreply.github.com
 	Independent until 2020-07-01
-	Daimler TSS from 2020-07-01
+	Daimler TSS from 2020-07-01 until 2022-04-01
+	Mercedes-Benz Tech Innovation from 2022-04-01
 seanshpark: saehie.park!samsung.com
 	Samsung Electronics Co. Ltd.
 seanson: seanson!users.noreply.github.com


### PR DESCRIPTION
Daimler TSS GmbH was renamed to Mercedes-Benz Tech Innovation GmbH on 2022-04-01.

Is there a way to create an alias for "Daimler TSS" and point to "Mercedes-Benz Tech Innovation"? In addition, this year all @daimler.com addresses are migrated to @mercedes-benz.com.

Or how would it be best to handle Daimler TSS and Mercedes-Benz Tech Innovation as the same company?