### PR TITLE
Update jannfis affiliation

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -402,8 +402,9 @@ jannau: j!jannau.net
 	Independent
 janneku: jannek!google.com, janneku!users.noreply.github.com
 	Google LLC
-jannfis: jannfis!users.noreply.github.com
-	Independent
+jannfis: jann!mistrust.net, jfischer!redhat.com, jannfis!users.noreply.github.com
+	Independent until 2021-01-31
+	Red Hat Inc. from 2021-02-01
 jannickfahlbusch: git!jf-projects.de, jannickfahlbusch!users.noreply.github.com
 	SAP
 jannikbecher: becher.jannik!gmail.com


### PR DESCRIPTION
Update developer's affiliation for jannfis GitHub account

Signed-off-by: Jann Fischer <jfischer@redhat.com>