### PR TITLE
correct robbkidd's affiliations

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -20031,14 +20031,10 @@ robbiet480: me!robbiet.us, robbiet480!users.noreply.github.com
 	Gyroscope Innovations
 robbiezhang: junjiez!microsoft.com, robbiezhang!users.noreply.github.com
 	Microsoft Corporation
-robbkidd: robb!thekidds.org
-	Independent until 2016-05-01
-	CyVerse from 2016-05-01 until 2016-07-01
-	Independent from 2016-07-01 until 2017-05-01
-	AWS from 2017-05-01 until 2017-08-01
-	Independent from 2017-08-01 until 2018-04-01
-	Aiqudo from 2018-04-01 until 2021-02-01
-	Peloton Technology Inc from 2021-02-01
+robbkidd: robb!thekidds.org, robbkidd!users.noreply.github.com, robbkidd!chef.io, robbkidd!honeycomb.io
+	Independent until 2015-09-01
+	Chef Software Inc. from 2015-09-01 until 2020-11-22
+	Hound Technology Inc. dba Honeycomb from 2020-11-23
 robbmanes: rmanes!redhat.com
 	Red Hat Inc.
 robbmanes: robb.manes!gmail.com


### PR DESCRIPTION
I suspect something automated might have pulled [robbmanes' affiliations](https://github.com/cncf/gitdm/blob/c0afc2a2cbdd5b2a61ab6da219ffaefec3ded873/developers_affiliations5.txt#L20044-L20051) under me.

![Him? Me?](https://user-images.githubusercontent.com/517302/196226449-2a463970-458c-4915-8b50-2c59050b8ac4.gif)
