### PR TITLE
Fix kentquirk affiliation

### DIFF
--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -10829,7 +10829,7 @@ kentonv: karthicoracle!gmail.com, kenton!cloudflare.com, kenton!sandstorm.io
 	Cloudflare Inc
 kentquirk: kentquirk!gmail.com, kentquirk!honeycomb.io, kentquirk!users.noreply.github.com
 	Hound Technology Inc. dba Honeycomb
-	Independent 2021-03-30 from 2100-01-01
+	Independent from 2000-01-01 to 2021-03-30
 kentrussell: kent.russell!amd.com
 	Advanced Micro Devices (AMD)
 kenvifire: kenvifire!users.noreply.github.com, mrwhite!163.com


### PR DESCRIPTION
My affiliation was mangled as part of a [big update](https://github.com/cncf/gitdm/commit/778325acc4cb5407b9b094f57c6af39c0e8fe752).

This is an attempt to repair it. 