### PR TITLE
Affiliate cailynse with Shopify

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -18076,6 +18076,8 @@ caillef: caillef!users.noreply.github.com
 	Loukoum from 2018-07-01 until 2020-02-01
 	Ankama from 2020-02-01 until 2020-08-01
 	Worth It Agency from 2020-08-01
+cailynse: cailyn.s.e!gmail.com, cailyn.edwards!shopify.com
+	Shopify
 cainelli: cainelli!users.noreply.github.com, fernando!cainelli.me
 	Inova until 2017-12-01
 	Independent from 2017-12-01 until 2018-01-01


### PR DESCRIPTION
Ensure contributions are attributed to Shopify for cailynse.