### PR TITLE
affiliate albertlockett with solo.io

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -3680,6 +3680,8 @@ albers: albers!users.noreply.github.com, github!albersweb.de, github!folk.de
 	Hamburger Software GmbH & Co. KG.
 albert-dong: albert.dongfeng!huawei.com
 	Huawei Technologies Co. Ltd
+albertlockett: albert.lockett!solo.io, albertlockett!users.noreply.github.com
+	Solo.io from 2022-11-28
 albertmichaelj: albertmichaelj!users.noreply.github.com
 	Independent
 albertoalmagro: albertoalmagro!gmail.com, albertoalmagro!users.noreply.github.com


### PR DESCRIPTION
Signed-off-by: Albert <albert.lockett@solo.io>