### PR TITLE
Add ARMO affiliations

### DIFF
--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -3076,6 +3076,8 @@ Aviv-Galmidi: AvivGalmidi!gmail.com
 	Trax Retail from 2019-12-01 until 2020-05-01
 	Independent from 2020-05-01 until 2020-10-01
 	Reblaze from 2020-10-01
+AvnerTzurArmo: AvnerTzurArmo!users.noreply.github.com, atzur!armosec.io, atzur!cyberarmor.io, 78496046+AvnerTzurArmo!users.noreply.github.com
+	ARMO until 2021-10-31
 Avni-Sharma: 16avnisharma!gmail.com, Avni-Sharma!users.noreply.github.com
 	Independent until 2018-02-01
 	Deloitte New Zealand from 2018-02-01 until 2018-04-01
@@ -3598,6 +3600,8 @@ Betula-L: Betula-L!users.noreply.github.com
 BeyerJC: BeyerJC!users.noreply.github.com
 	QSC AG until 2018-09-01
 	Plusnet plc from 2018-09-01
+Bezbran: Bezbran!users.noreply.github.com, bbrandwine!armosec.io, bbrandwine!cyberarmor.io, bez!armosec.io
+	ARMO
 Bezier89: TwistedLadder!gmail.com, jasexton!google.com
 	Google LLC
 Bhadram: Bhadram!users.noreply.github.com, varkabhadram!gmail.com
@@ -5581,9 +5585,9 @@ Daniel-B-Smith: Daniel-B-Smith!users.noreply.github.com, dbsmith!google.com
 Daniel-G-Jeong: gshark.jeong!gmail.com
 	Texas Instruments Incorporated until 2017-03-01
 	Maxim Integrated Products from 2017-03-01
-Daniel-GrunbergerCA: Daniel-GrunbergerCA!users.noreply.github.com
-	Independent until 2021-09-01
-	ARMO from 2021-09-01
+Daniel-GrunbergerCA: Daniel-GrunbergerCA!users.noreply.github.com, danielg!armosec.io, 84905812+Daniel-GrunbergerCA!users.noreply.github.com, grunbagrunba!gmail.com
+	Independent until 2021-01-18
+	ARMO from 2021-01-18
 Daniel-Vaz: Daniel-Vaz!users.noreply.github.com, dafivaz!hotmail.com
 	NOS SGPS until 2016-08-01
 	Independent from 2016-08-01 until 2018-08-01
@@ -12841,6 +12845,8 @@ LionelJouin: LionelJouin!users.noreply.github.com
 	Ericsson from 2019-06-01
 LionsAd: fabianfranz.oss!gmail.com
 	Drupal
+LiorAlafiArmo: LiorAlafiArmo!users.noreply.github.com, lalafi!armosec.io, lalafi!cyberarmor.io, 78410729+LiorAlafiArmo!users.noreply.github.com
+	ARMO until 2022-08-31
 LiorLieberman: LiorLieberman!users.noreply.github.com
 	Independent until 2018-02-01
 	Dortech Information Technology from 2018-02-01 until 2020-01-01
@@ -14747,6 +14753,8 @@ MosesAlexander: 00moses.alexander00!gmail.com
 	Flex from 2017-03-01
 Moshe-Immerman: Moshe-Immerman!users.noreply.github.com, moshe.immerman!gmail.com
 	Flanksource
+Moshe-Rappaport-CA: Moshe-Rappaport-CA!users.noreply.github.com, 89577611+Moshe-Rappaport-CA!users.noreply.github.com, moshep!armosec.io
+	ARMO
 Moshem123: Moshem123!users.noreply.github.com, moshe.avni!naturalint.com
 	IAF - Israeli Air Force until 2014-10-01
 	Independent from 2014-10-01 until 2015-01-01
@@ -15850,6 +15858,8 @@ OleksiiDuzhyi: OleksiiDuzhyi!users.noreply.github.com
 	DEVOLER from 2014-07-01 until 2015-03-01
 	Luxoft Global Operations GmbH from 2015-03-01 until 2015-11-01
 	Wix.com Ltd from 2015-11-01
+OleksiiHahren: OleksiiHahren!users.noreply.github.com, oleksiih!armosec.io
+	ARMO
 OleksiiPasihnyk: OleksiiPasihnyk!users.noreply.github.com
 	Life360
 OliPerraul: OliPerraul!users.noreply.github.com
@@ -23189,10 +23199,10 @@ Yirgacheffe: aaron.yuu!outlook.com
 	Volvo from 2022-03-01
 Yisaer: Yisaer!users.noreply.github.com, disxiaofei!163.com
 	PingCAP
-YiscahLevySilas1: YiscahLevySilas1!users.noreply.github.com
+YiscahLevySilas1: YiscahLevySilas!users.noreply.github.com, 80635572+YiscahLevySilas1!users.noreply.github.com, yiscahls!armosec.io
 	Independent until 2018-06-01
-	Silas Civil & Structural Engineering from 2018-06-01 until 2021-01-01
-	ARMO from 2021-01-01
+	Silas Civil & Structural Engineering from 2018-06-01 until 2021-12-01
+	ARMO from 2021-12-01
 Yiyiyimu: wosoyoung!gmail.com
 	Independent until 2020-07-01
 	Alibaba.com from 2020-07-01 until 2020-09-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -6691,11 +6691,11 @@ amirkarimi: a.karimi.k!gmail.com
 	Acceptto from 2014-08-01 until 2017-04-01
 	Walt Disney Animation Studios from 2017-04-01 until 2019-03-01
 	Acceptto from 2019-03-01
-amirmalka: amirm!armosec.io
+amirmalka: amirmalka!users.noreply.github.com, amirm!armosec.io
 	Dell EMC until 2017-09-01
 	Cognyte from 2017-09-01 until 2020-10-01
-	OTORIO from 2020-10-01 until 2022-04-01
-	ARMO from 2022-04-01
+	OTORIO from 2020-10-01 until 2022-04-24
+	ARMO from 2022-04-24
 amirshalit: amir.shalit!hpe.com
 	HP Inc.
 amirv: amir!vadai.me, amirv!mellanox.com, amirva!mellanox.com
@@ -12513,9 +12513,10 @@ avpatel: anup!brainfault.org, anup.patel!wdc.com
 	Broadcom Corporation from 2015-07-01 until 2017-11-01
 	Qualcomm from 2017-11-01 until 2018-12-01
 	Western from 2018-12-01
-avrahams: avrahams!users.noreply.github.com
+avrahams: avrahams!users.noreply.github.com, avrahams!armosec.io
 	International Business Machines Corporation until 2016-05-01
-	Persistent Systems from 2016-05-01
+	Persistent Systems from 2016-05-01 until 2022-06-06
+	ARMO from 2022-06-06
 avram: ajlyon!gmail.com
 	Scopely Inc
 avranju: avranju!gmail.com, avranju!users.noreply.github.com, rajave!microsoft.com, tomkins.hc!gmail.com
@@ -23134,6 +23135,8 @@ cig0: cig0!users.noreply.github.com
 	Independent from 2020-10-01 until 2020-12-01
 	Altoros from 2020-12-01 until 2021-06-01
 	POAP from 2021-06-01
+cigra: cigra!users.noreply.github.com, marinas!armosec.io
+	ARMO
 cihangir: cihangir!koding.com, cihangir!savas.io, cihangir!users.noreply.github.com, info!crypt.ee
 	Koding
 cihangirbesiktas: cihangirbesiktas!users.noreply.github.com

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -1186,8 +1186,9 @@ craigbilner: craig.bilner!gmail.com, craigbilner!users.noreply.github.com
 	Trainline.com Limited from 2015-07-15 until 2016-02-15
 	Site Point from 2016-02-15 until 2017-05-15
 	News UK from 2017-05-15
-craigbox: craig.box!gmail.com, craigbox!users.noreply.github.com
-	Google LLC
+craigbox: craig.box!gmail.com, craigbox!google.com, craigb!armosec.io, craigbox!users.noreply.github.com
+	Google LLC until 2022-10-18
+	ARMO from 2022-10-18
 craigbr: craig.bryant!hp.com, craig.bryant!hpe.com
 	HP Inc. until 2015-10-31
 	HP Inc. from 2015-10-31
@@ -10457,9 +10458,9 @@ dwerder: dwerder!users.noreply.github.com
 	DCSO Deutsche Cyber-Sicherheitsorganisation from 2017-11-01 until 2018-05-01
 	Cyren from 2018-05-01 until 2021-06-01
 	DKB from 2021-06-01
-dwertent: dwertent!users.noreply.github.com
+dwertent: dwertent!users.noreply.github.com, dwertent!armosec.io, dwertent!cyberarmor.io, 64066841+dwertent!users.noreply.github.com
 	L&T Infotech until 2018-12-01
-	Cyber Armor from 2018-12-01
+	ARMO from 2018-12-01
 dwery: a.zummo!towertech.it
 	Tower Technologies
 dwhiteddsoft: davwhite!microsoft.com, dwhiteddsoft!users.noreply.github.com

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -17006,6 +17006,8 @@ koonchen: zpkoon!gmail.com
 	Independent
 koooge: koooge!users.noreply.github.com, koooooge!gmail.com
 	Independent
+kooomix: kooomix!users.noreply.github.com, eranm!armosec.io, emadar!gmail.com
+	ARMO
 koorgoo: koorgoo!gmail.com, koorgoo!users.noreply.github.com
 	Tickets Cloud until 2016-08-01
 	Independent from 2016-08-01 until 2017-02-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -1600,6 +1600,8 @@ matancarmeli7: matancarmeli7!users.noreply.github.com
 	Independent until 2016-12-01
 	J6 & Cyber Defense Directorate from 2016-12-01 until 2020-08-01
 	International Business Machines Corporation from 2020-08-01
+matanshk: matanshk!users.noreply.github.com, mshkalim!armosec.io
+	ARMO
 matchge-ca: matchge-ca!users.noreply.github.com
 	PingCAP
 matchstick: gilesb!gmail.com, matchstick!users.noreply.github.com, mrubin!google.com
@@ -21834,6 +21836,8 @@ radoslaw-wielonski-nc: radoslaw-wielonski-nc!users.noreply.github.com
 	Independent from 2020-02-01 until 2020-04-01
 	JMR from 2020-04-01 until 2021-06-01
 	International Business Machines Corporation from 2021-06-01
+radoslawdob: radoslawdob!users.noreply.github.com, radoslawd!armosec.io
+	ARMO
 radsimu: radsimu!users.noreply.github.com
 	Housatonic until 2016-02-01
 	Amazon from 2016-02-01 until 2016-09-01
@@ -23376,6 +23380,8 @@ rcoh: rcoh!rcoh.me, rcoh!users.noreply.github.com
 	Independent
 rcoh: russell.r.cohen!gmail.com
 	Russell Cohen
+rcohencyberarmor: rcohencyberarmor!users.noreply.github.com, rcohen!armosec.io, rcohen!cyberarmor.io, 84019060+rcohencyberarmor!users.noreply.github.com
+	ARMO
 rcolline: rcolline!users.noreply.github.com
 	Google LLC
 rcorre: rcorre!users.noreply.github.com, ryan!rcorre.net

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -2719,10 +2719,10 @@ rotem-codefresh: rotem.cohen!codefresh.io
 	Superfly Insights from 2018-12-01 until 2020-07-01
 	Independent from 2020-07-01 until 2021-08-01
 	Codefresh Inc. from 2021-08-01
-rotemamsa: rotemamsa!users.noreply.github.com
+rotemamsa: rotemamsa!users.noreply.github.com, rrefael!armosec.io, 48656234+rotemamsa!users.noreply.github.com, rotem!armosec.io
 	Independent until 2021-01-01
-	Cognyte from 2021-01-01 until 2021-08-01
-	ARMO from 2021-08-01
+	Cognyte from 2021-01-01 until 2021-12-09
+	ARMO from 2021-12-09
 rotemjac: rotem_jac!yahoo.com, rotemjac!users.noreply.github.com
 	Tradency until 2016-02-01
 	DayTwo from 2016-02-01 until 2018-09-01
@@ -9027,6 +9027,8 @@ shlyopin: shlyopin!yandex.ru
 	MediaMarktSaturn until 2018-08-01
 	Independent from 2018-08-01 until 2019-09-01
 	НПО Компо from 2019-09-01
+shm12: shm12!users.noreply.github.com, shmuelb!armosec.io
+	ARMO until 2022-11-30
 shmao: shmao!microsoft.com, shmao!users.noreply.github.com
 	Microsoft Corporation until 2018-01-01
 	Google LLC from 2018-01-01
@@ -10726,7 +10728,7 @@ slapula: slapula!users.noreply.github.com
 	Clarity from 2022-07-01
 slash-lib: llib!google.com, llib!origami.mtv.corp.google.com, slash-lib!users.noreply.github.com
 	Google LLC
-slashben: slashben!users.noreply.github.com
+slashben: slashben!users.noreply.github.com, ben!armosec.io, bhirschb!cyberarmor.io, 59160382+slashben!users.noreply.github.com
 	Cisco until 2017-07-01
 	ARMO from 2017-07-01
 slashdd: eric.desrochers!canonical.com
@@ -15764,6 +15766,8 @@ szemek: przemyslaw.dabek!gmail.com, szemek!users.noreply.github.com
 	Base until 2014-03-01
 	Lunar A/S from 2014-03-01 until 2016-02-01
 	UXPin from 2016-02-01
+szhyvotov: szhyvotov!users.noreply.github.com, szhyvotov!armosec.io
+	ARMO
 szibis: szibis!gmail.com
 	Glencore until 2017-01-01
 	Swiss RE from 2017-01-01 until 2017-11-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -987,12 +987,12 @@ vladimirvivien: vivienv!vmware.com, vladimir.vivien!gmail.com, vladimirvivien!us
 	Xor from 2015-05-01 until 2015-10-01
 	Dell from 2015-10-01 until 2018-03-01
 	VMware Inc. from 2018-03-01
-vladklokun: vladklokun!users.noreply.github.com
+vladklokun: vladklokun!users.noreply.github.com, vladk!armosec.io, vvklokun!protonmail.ch, vklokun!protonmail.com
 	Independent until 2019-03-01
 	ДЗЕН from 2019-03-01 until 2020-11-01
 	Independent from 2020-11-01 until 2021-06-01
-	EVO from 2021-06-01 until 2022-06-01
-	ARMO from 2022-06-01
+	EVO from 2021-06-01 until 2022-05-30
+	ARMO from 2022-05-30
 vladlosev: vladlosev!users.noreply.github.com
 	Google LLC until 2014-02-01
 	VSCO from 2014-02-01
@@ -6961,6 +6961,8 @@ yuklia: yuliakostrikova!gmail.com
 	Independent from 2017-09-01 until 2017-12-01
 	CodeTiburon from 2017-12-01 until 2021-01-01
 	Spryker from 2021-01-01
+yuleib: yuleib!users.noreply.github.com, yuvall!armosec.io
+	ARMO
 yulin-liang: yulin-liang!users.noreply.github.com
 	Tencent Holdings Limited until 2017-07-01
 	Independent from 2017-07-01 until 2018-02-01


### PR DESCRIPTION
Add and update Kubescape contributors as part of sandbox onboarding.

Signed-off-by: Craig Box <craigb@armosec.io>