### PR TITLE
update DaoCloud developers' information

### DIFF
--- a/company_developers10.txt
+++ b/company_developers10.txt
@@ -3156,9 +3156,6 @@ daenet:
 	ddobric: ddobric!users.noreply.github.com
 dalab:
 	zinking: zinking!users.noreply.github.com, zinking3!gmail.com
-daocloud:
-	cyclinder: cyclinder!users.noreply.github.com
-	gssjl2008: gssjl2008!users.noreply.github.com
 dareCode:
 	airadier: airadier!gmail.com, airadier!users.noreply.github.com from 2017-11-01 until 2019-08-01
 	marco2704: josephlawlcm!gmail.com, marcodavalosmantilla!gmail.com from 2018-01-01

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -10059,7 +10059,10 @@ DaoCloud Network Technology Co. Ltd.:
 	JiaweiGithub: JiaweiGithub!users.noreply.github.com, jiawei.liu!daocloud.io
 	JoeWrightss: 42261994+joewrightss!users.noreply.github.com, JoeWrightss!users.noreply.github.com, zhoulin.xie!daocloud.io
 	Michelle951: Michelle951!users.noreply.github.com
+	Onion-of-dreamed: chong.yuan!daocloud.io, Onion-of-dreamed!users.noreply.github.com
 	OwenYang1996: OwenYang1996!users.noreply.github.com, dev!ryanwolhuter.com, gaur.var!gmail.com, owen.yang!daocloud.io
+	Penguin-zlh: lihan.zhou!daocloud.io, Penguin-zlh!users.noreply.github.com
+	Rei1010: wen.rui!daocloud.io, 326028565!qq.com, Rei1010!users.noreply.github.com
 	Revolution1: Revolution1!users.noreply.github.com, revol.cai!daocloud.io
 	SAMZONG: samzong.lu!gmail.com
 	SenXuDC: SenXuDC!users.noreply.github.com, sen.xu!daocloud.io
@@ -10078,13 +10081,17 @@ DaoCloud Network Technology Co. Ltd.:
 	carlory: carlory!users.noreply.github.com, Carlory!users.noreply.github.com, baofa.fan!daocloud.io
 	chaunceyjiang: chaunceyjiang!gmail.com, chaunceyjiang!users.noreply.github.com, xingyan.jiang!daocloud.io
 	chuanhaojin: chuanhaojin!users.noreply.github.com
+	cl2017: chenlin.liu!daocloud.io, cl2017!users.noreply.github.com
 	cyclinder: cyclinder!users.noreply.github.com
+	dapengJacky: dapengJacky!users.noreply.github.com, peng.chen!daocloud.io
 	dbdd4us: dbdd4us!users.noreply.github.com, wangtong2712!gmail.com, yunda.wang!daocloud.io
 	dengyi1996: dengyi0215!gmail.com, dengyi1996!users.noreply.github.com, yi.deng!daocloud.io
 	donggangcj: donggangcj!users.noreply.github.com
+	donghui12: 164631543!qq.com, donghui.jiang!daocloud.io, donghui12!users.noreply.github.com
 	drivebyer: wuyangmuc!gmail.com
 	dzzg: dzzg!users.noreply.github.com, zhengguang.zhu!daocloud.io
 	ethan-daocloud: ethan-daocloud!users.noreply.github.com, guangming.wang!daocloud.io
+	falser101: jianfei!daocloud.io, falser101!users.noreply.github.com
 	gq94205: 32254120+gq94205!users.noreply.github.com, gq94205!users.noreply.github.com
 	gssjl2008: gssjl2008!users.noreply.github.com
 	hanxiaop: hanxiaop!google.com, hanxiaop!usc.edu, hanxiaop!users.noreply.github.com, hanxiaop8!gmail.com, hanxiaop8!outlook.com, michael.han!daocloud.io, xiaopeng.han-iog!daocloud.io
@@ -10092,8 +10099,10 @@ DaoCloud Network Technology Co. Ltd.:
 	huan555: huan555!users.noreply.github.com
 	huangjiuyuan: huangjiuyuan!163.com, huangjiuyuan!users.noreply.github.com, jiuyuan.huang!daocloud.io, stian.bay!outlook.com from 2017-05-01 until 2018-09-01
 	jamiefang: jamie.fang!daocloud.io, jamiefang!users.noreply.github.com
+	jpanda-cn: qi.han!daocloud.io, jpanda-cn!user.noreply.github.com
 	kebe7jun: kebe.liu!daocloud.io, kebe7jun!users.noreply.github.com, mail!kebe7jun.com
 	kerthcet: kerthcet!gmail.com
+	liyuerich: yue.li!daocloud.io, liyuerich!user.noreply.github.com
 	lrx0014: lrx0014!hotmail.com, lrx0014!users.noreply.github.com, renxiang.li!daocloud.io
 	mengjiao-liu: liumengjiao69!gmail.com, mengjiao.liu!daocloud.io, mengjiao.liu!user.noreply.github.com
 	my-git9: my-git9!users.noreply.github.com, xin.li!daocloud.io
@@ -10105,6 +10114,7 @@ DaoCloud Network Technology Co. Ltd.:
 	panpan0000: panpan0000!msn.com, panpan0000!users.noreply.github.com from 2018-07-01
 	qar: anran.qiao!daocloud.io, olegakbarov!gmail.com, pinkaminadianepie!gmail.com, qar!users.noreply.github.com, qiaoanran!gmail.com
 	sakeven: jc5930!sina.cn, sakeven!users.noreply.github.com, sakeven.jiang!daocloud.io
+	tangming1996: ming.tang!daocloud.io, tangming1996!users.noreply.github.com
 	tangyanhan: tangyanhan!users.noreply.github.com from 2018-03-01 until 2020-07-01
 	tomwei7: tomwei7!users.noreply.github.com
 	vonsago: vonsago!users.noreply.github.com

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -6803,8 +6803,6 @@ Computer Task Group Inc.:
 	Cicatrice: Cicatrice!users.noreply.github.com until 2016-05-01
 Computerized Assessments and Learning:
 	theherk: theherk!gmail.com, theherk!users.noreply.github.com until 2015-07-01
-Computershare:
-	ErikJiang: ErikJiang!users.noreply.github.com until 2017-11-01
 Computing Society:
 	matty234: matthew!mattbrown.guru, matty234!users.noreply.github.com from 2017-04-01 until 2018-04-01
 Computology:
@@ -10046,16 +10044,19 @@ DaoCloud Network Technology Co. Ltd.:
 	AdamDang: AdamDang!users.noreply.github.com, adam.dang!daocloud.io
 	AllenZMC: AllenZMC!users.noreply.github.com, zhongming.chang!daocloud.io
 	BingGuanqi: BingGuanqi!users.noreply.github.com
-	Carlory: Carlory!users.noreply.github.com, baofa.fan!daocloud.io
 	CharlesLvw: 17763040192!163.com, CharlesLvw!users.noreply.github.com
-	Coderhypo: Coderhypo!users.noreply.github.com
+	Coderhypo: Coderhypo!users.noreply.github.com, zhechun.chen!daocloud.io
+	ErikJiang: ErikJiang!users.noreply.github.com, bo.jiang!daocloud.io
+	FangtingYan: FangtingYan!users.noreply.github.com, fangting.yan!daocloud.io
 	Fish-pro: Fish-pro!users.noreply.github.com
+	Frapschen: Frapschen!users.noreply.github.com, minquan.chen!daocloud.io
 	FreeZhang61: listenersheng!gmail.com
 	Haleygo: Haleygo!users.noreply.github.com, hui.wang!daocloud.io
 	HeavenTonight: HeavenTonight!users.noreply.github.com
 	HuiWang0025: 39937150+huiwang0025!users.noreply.github.com
 	Iceber: Iceber!user.noreply.github.com, caiwei95!hotmail.com, wei.cai-nat!daocloud.io
 	JaredTan95: JaredTan95!users.noreply.github.com, jian.tan!daocloud.io
+	JiaweiGithub: JiaweiGithub!users.noreply.github.com, jiawei.liu!daocloud.io
 	JoeWrightss: 42261994+joewrightss!users.noreply.github.com, JoeWrightss!users.noreply.github.com, zhoulin.xie!daocloud.io
 	Michelle951: Michelle951!users.noreply.github.com
 	OwenYang1996: OwenYang1996!users.noreply.github.com, dev!ryanwolhuter.com, gaur.var!gmail.com, owen.yang!daocloud.io
@@ -10068,12 +10069,16 @@ DaoCloud Network Technology Co. Ltd.:
 	WillardHu: WillardHu!users.noreply.github.com, wei.hu!daocloud.io
 	XSAM: XSAM!users.noreply.github.com, sam!samxie.me, sam.xie!liulishuo.com, xsambundy!gmail.com until 2018-02-01
 	Ye-Ting: Ye-Ting!users.noreply.github.com, ting.ye!daocloud.io
+	Zhuzhenghao: Zhuzhenghao!users.noreply.github.com, zhenghao.zhu!daocloud.io
+	alexzhc: alexzhc!users.noreply.github.com, alex.zheng!daocloud.io
 	allencloud: allen.sun!daocloud.io, allencloud!users.noreply.github.com, allensun.shl!alibaba-inc.com, hi!gunargessner.com, shlallen1990!gmail.com from 2014-12-01 until 2018-09-01
 	anniedy: anniedy!users.noreply.github.com, yu.dong!daocloud.io
 	arugaki: arugaki!users.noreply.github.com, arugaki.wei!daocloud.io
 	brooksmtownsend: brooksmtownsend!gmail.com from 2018-08-01 until 2019-03-01
+	carlory: carlory!users.noreply.github.com, Carlory!users.noreply.github.com, baofa.fan!daocloud.io
 	chaunceyjiang: chaunceyjiang!gmail.com, chaunceyjiang!users.noreply.github.com, xingyan.jiang!daocloud.io
 	chuanhaojin: chuanhaojin!users.noreply.github.com
+	cyclinder: cyclinder!users.noreply.github.com
 	dbdd4us: dbdd4us!users.noreply.github.com, wangtong2712!gmail.com, yunda.wang!daocloud.io
 	dengyi1996: dengyi0215!gmail.com, dengyi1996!users.noreply.github.com, yi.deng!daocloud.io
 	donggangcj: donggangcj!users.noreply.github.com
@@ -10081,8 +10086,10 @@ DaoCloud Network Technology Co. Ltd.:
 	dzzg: dzzg!users.noreply.github.com, zhengguang.zhu!daocloud.io
 	ethan-daocloud: ethan-daocloud!users.noreply.github.com, guangming.wang!daocloud.io
 	gq94205: 32254120+gq94205!users.noreply.github.com, gq94205!users.noreply.github.com
+	gssjl2008: gssjl2008!users.noreply.github.com
 	hanxiaop: hanxiaop!google.com, hanxiaop!usc.edu, hanxiaop!users.noreply.github.com, hanxiaop8!gmail.com, hanxiaop8!outlook.com, michael.han!daocloud.io, xiaopeng.han-iog!daocloud.io
 	heliping: heliping!users.noreply.github.com, liping.he!daocloud.io
+	huan555: huan555!users.noreply.github.com
 	huangjiuyuan: huangjiuyuan!163.com, huangjiuyuan!users.noreply.github.com, jiuyuan.huang!daocloud.io, stian.bay!outlook.com from 2017-05-01 until 2018-09-01
 	jamiefang: jamie.fang!daocloud.io, jamiefang!users.noreply.github.com
 	kebe7jun: kebe.liu!daocloud.io, kebe7jun!users.noreply.github.com, mail!kebe7jun.com
@@ -10095,6 +10102,7 @@ DaoCloud Network Technology Co. Ltd.:
 	niulechuan: niulechuan!users.noreply.github.com
 	orangegzx: orangegzx!users.noreply.github.com, zuxia.ge!daocloud.io
 	pacoxu: paco.xu!daocloud.io, pacoxu!users.noreply.github.com, roollingstone!gmail.com
+	panpan0000: panpan0000!msn.com, panpan0000!users.noreply.github.com from 2018-07-01
 	qar: anran.qiao!daocloud.io, olegakbarov!gmail.com, pinkaminadianepie!gmail.com, qar!users.noreply.github.com, qiaoanran!gmail.com
 	sakeven: jc5930!sina.cn, sakeven!users.noreply.github.com, sakeven.jiang!daocloud.io
 	tangyanhan: tangyanhan!users.noreply.github.com from 2018-03-01 until 2020-07-01
@@ -10128,10 +10136,6 @@ DaoCloud Network Technology Co. Ltd.:
 	zjcomeon: 159109799!qq.com, zhenjia.wang!daocloud.io, zjcomeon!users.noreply.github.com
 	zqm19941101: qinmou.zhang!daocloud.io, zqm19941101!users.noreply.github.com
 	zwwhdls: 33822635+zwwhdls!users.noreply.github.com, zwwhdls!users.noreply.github.com from 2017-11-01 until 2020-03-01
-DaoCloud.i:
-	panpan0000: panpan0000!msn.com, panpan0000!users.noreply.github.com from 2018-07-01
-Daocloud:
-	huan555: huan555!users.noreply.github.com
 Dapi:
 	mohammed-ali-1: mohammad10596!gmail.com, mohammed-ali-1!users.noreply.github.com, mohammed.alameen!protonmail.ch from 2019-07-01 until 2021-05-01
 Dapper Labs:

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -11442,6 +11442,7 @@ Dell EMC:
 	nikolay-t: nikolay-t!users.noreply.github.com
 	njiandan1255: njiandan1255!users.noreply.github.com from 2015-01-01 until 2015-08-01
 	ntolia: ntolia!gmail.com, ntolia!users.noreply.github.com from 2014-10-01 until 2016-09-01
+	pacoxu: paco.xu!daocloud.io, pacoxu!users.noreply.github.com, roollingstone!gmail.com until 2016-04-18
 	panpan0000: panpan0000!msn.com, panpan0000!users.noreply.github.com until 2018-07-01
 	phenoxim: phenoxim!gmail.com until 2015-10-01
 	phuongatemc: phuong.hoang!emc.com from 2015-03-01

--- a/company_developers5.txt
+++ b/company_developers5.txt
@@ -2585,7 +2585,6 @@ Independent:
 	ZhimaoL: ZhimaoL!users.noreply.github.com until 2015-05-01, from 2015-08-01 until 2017-05-01, from 2017-08-01 until 2018-01-01
 	ZhouyihaiDing: ZhouyihaiDing!users.noreply.github.com, ddyihai!google.com from 2016-06-01 until 2017-05-01
 	ZhuGongpu: ZhuGongpu!users.noreply.github.com from 2019-08-01 until 2020-05-01
-	Zhuzhenghao: Zhuzhenghao!users.noreply.github.com
 	ZihanJiang96: ZihanJiang96!users.noreply.github.com, jiangzhsysu!gmail.com until 2018-01-01
 	ZiyamSanthosh: ZiyamSanthosh!users.noreply.github.com until 2020-07-01, from 2021-06-01 until 2022-06-01
 	Ziyang2go: Ziyang2go!users.noreply.github.com until 2016-09-01

--- a/company_developers6.txt
+++ b/company_developers6.txt
@@ -12735,7 +12735,6 @@ MYLAPS:
 	martinbeentjes: martin!beentjes.me from 2015-07-01 until 2015-08-01
 MYOB:
 	Afshin-Ofx: Afshin-Ofx!users.noreply.github.com from 2019-10-01 until 2020-06-01
-	ErikJiang: ErikJiang!users.noreply.github.com from 2017-11-01 until 2022-04-01
 	Niksko: Niksko!users.noreply.github.com, n.skoufis!gmail.com from 2018-04-01
 	ProTip: ProTip!users.noreply.github.com until 2015-06-01
 	SongGithub: SongGithub!users.noreply.github.com, songjin!hotmail.com from 2017-05-01 until 2018-12-01

--- a/company_developers9.txt
+++ b/company_developers9.txt
@@ -11738,7 +11738,6 @@ Vandewiele:
 VandyApps:
 	SBhat35: sachit.s.bhat!vanderbilt.edu until 2016-05-01
 Vanguard:
-	ErikJiang: ErikJiang!users.noreply.github.com from 2022-04-01
 	humivo: hvoam!amazon.com from 2019-04-01 until 2019-12-01
 	louis-murray: congfairy2536!gmail.com, louis-murray!users.noreply.github.com, oscar.99.tris!gmail.com, playa1!gmail.com, steffen.butzer!outlook.com from 2015-12-01 until 2016-08-01
 	rokka-n: rokka-n!users.noreply.github.com, roman!naumenko.ca from 2019-03-01 until 2020-08-01

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -4423,7 +4423,7 @@ CarloGarcia: CarloGarcia!users.noreply.github.com
 	Solidsoft Reply until 2016-11-01
 	Codit from 2016-11-01 until 2021-10-01
 	Sourced from 2021-10-01
-Carlory: Carlory!users.noreply.github.com, baofa.fan!daocloud.io
+carlory: carlory!users.noreply.github.com, Carlory!users.noreply.github.com, baofa.fan!daocloud.io
 	DaoCloud Network Technology Co. Ltd.
 CarlosLanderas: CarlosLanderas!users.noreply.github.com, carlos.landeras!gmail.com
 	hna Mutualidad de los Arquitectos y Químicos until 2015-03-01
@@ -7110,10 +7110,8 @@ Erik-Securenative: Erik-Securenative!users.noreply.github.com
 	SecureNative Inc. from 2019-05-01
 ErikBean: ErikBean!users.noreply.github.com, erikbean08!gmail.com
 	Independent
-ErikJiang: ErikJiang!users.noreply.github.com
-	Computershare until 2017-11-01
-	MYOB from 2017-11-01 until 2022-04-01
-	Vanguard from 2022-04-01
+ErikJiang: ErikJiang!users.noreply.github.com, bo.jiang!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 ErikLundJensen: ErikLundJensen!users.noreply.github.com
 	Nordea Bank until 2015-06-01
 	Independent from 2015-06-01 until 2015-08-01
@@ -7400,6 +7398,8 @@ FancyFane: fane!planetscale.com
 	PlanetScale
 FanghuiQ: fanghui!google.com
 	Google LLC
+FangtingYan: FangtingYan!users.noreply.github.com, fangting.yan!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 Fank: fank!users.noreply.github.com
 	Independent
 Fantoccini: Fantoccini!users.noreply.github.com, paladinroar!gmail.com
@@ -7761,6 +7761,8 @@ FransUrbo: FransUrbo!users.noreply.github.com, turbo!bayour.com
 	Royal Pharmaceutical Society
 FrantaM: frantisek.mejta!studentagency.cz, mejta!rewor.cz
 	Independent
+Frapschen: Frapschen!users.noreply.github.com, minquan.chen!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 Frassle: Frassle!users.noreply.github.com, frassle!gmail.com
 	ARM until 2018-08-01
 	OpenTK from 2018-08-01 until 2018-09-01
@@ -10729,6 +10731,8 @@ JianyuZhan: nasa4836!gmail.com
 	快仓 from 2019-01-01
 JiaoDean: JiaoDean!users.noreply.github.com
 	eleme
+JiaweiGithub: JiaweiGithub!users.noreply.github.com, jiawei.liu!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 Jiawei0227: jiaweiwang!google.com
 	Independent until 2017-08-01
 	SAP from 2017-08-01 until 2018-02-01
@@ -23603,8 +23607,8 @@ ZhuZhengyi: ZhuZhengyi!users.noreply.github.com, justice_103!126.com, zhengyi.zh
 	BEIKE (Beijing) Technology Corp. Ltd. from 2021-06-30
 ZhuangYuZY: yuzcdl!cn.ibm.com
 	International Business Machines Corporation
-Zhuzhenghao: Zhuzhenghao!users.noreply.github.com
-	Independent
+Zhuzhenghao: Zhuzhenghao!users.noreply.github.com, zhenghao.zhu!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 ZideChen0: ZideChen0!users.noreply.github.com, zide.chen!intel.com
 	Intel Corporation
 ZiggyMaes: ZiggyMaes!users.noreply.github.com

--- a/developers_affiliations1.txt
+++ b/developers_affiliations1.txt
@@ -15956,6 +15956,8 @@ OneCricketeer: OneCricketeer!users.noreply.github.com
 	Inspired Intellect from 2020-01-01
 OneOfMany07: jmillenbach!gmail.com
 	NVIDIA Corporation
+Onion-of-dreamed: chong.yuan!daocloud.io, Onion-of-dreamed!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 Onlinehead: Onlinehead!users.noreply.github.com
 	ClusterK until 2014-11-01
 	Gaijin Entertainment from 2014-11-01 until 2017-02-01
@@ -16435,6 +16437,8 @@ PenelopeFudd: PenelopeFudd!users.noreply.github.com
 	Amazon until 2019-05-01
 	Loop from 2019-05-01 until 2020-03-01
 	Unbounce from 2020-03-01
+Penguin-zlh: lihan.zhou!daocloud.io, Penguin-zlh!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 PennyScissors: PennyScissors!users.noreply.github.com
 	Independent until 2015-05-01
 	L3Harris from 2015-05-01 until 2020-03-01
@@ -17698,6 +17702,8 @@ RehanSaeed: RehanSaeed!users.noreply.github.com, rehansaeed!gmail.com
 	GAM until 2015-10-01
 	Bridge from 2015-10-01 until 2019-03-01
 	Microsoft Corporation from 2019-03-01
+Rei1010: wen.rui!daocloud.io, 326028565!qq.com, Rei1010!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 ReiReiRei: ldmitriy!ru.ibm.com
 	International Business Machines Corporation
 Reichl: m.reichl!fivetechno.de

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -23411,6 +23411,8 @@ ckujau: lists!nerdbynature.de
 	ConSol
 ckyoog: ckyoog!gmail.com
 	Fortinet Inc.
+cl2017: chenlin.liu!daocloud.io, cl2017!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 claas-fridtjof-lisowski: claas-fridtjof-lisowski!users.noreply.github.com
 	Körber Pharma until 2017-06-01
 	Kreditech from 2017-06-01 until 2019-12-01

--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -5460,6 +5460,8 @@ alexykot: alexykot!gmail.com, alexykot!users.noreply.github.com
 	BXTerminal until 2017-04-01
 	BlockEx from 2017-04-01 until 2018-11-01
 	Ziglu from 2018-11-01
+alexzhc: alexzhc!users.noreply.github.com, alex.zheng!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 alexzielenski: zielenski!google.com
 	Independent until 2016-05-01
 	Apple Inc. from 2016-05-01 until 2016-08-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -3718,6 +3718,8 @@ daogilvie: daogilvie!users.noreply.github.com
 	OVO from 2021-03-01
 daor-oti: daor!demant.com, daor-oti!users.noreply.github.com
 	Oticon A/S aka. Demant
+dapengJacky: dapengJacky!users.noreply.github.com, peng.chen!daocloud.io
+	DaoCloud Network Technology Co. Ltd.
 dapengzhang0: dapeng.zhang!gmail.com, dapengzhang0!users.noreply.github.com, zdapeng!google.com
 	Oracle America Inc. until 2016-04-01
 	Google LLC from 2016-04-01
@@ -8788,6 +8790,8 @@ dongdong004: chenyudong!espressif.com, xd_ydchen!163.com
 dongfsgf: dongfsgf!users.noreply.github.com
 	Ali
 donggangcj: donggangcj!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
+donghui12: 164631543!qq.com, donghui.jiang!daocloud.io, donghui12!users.noreply.github.com
 	DaoCloud Network Technology Co. Ltd.
 dongjoon-hyun: dongjoon!apache.org, dongjoon-hyun!users.noreply.github.com
 	Apache
@@ -14903,6 +14907,8 @@ fallard84: fallard84!users.noreply.github.com
 fallrisk: fallrisk!users.noreply.github.com, jwatson5!gmail.com
 	Galil Motion Control until 2018-02-01
 	Fetch Robotics from 2018-02-01
+falser101: jianfei!daocloud.io, falser101!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 falsyvalues: falsyvalues!users.noreply.github.com, mylith!gmail.com
 	CompuGroup Medical USA until 2015-06-01
 	Independent from 2015-06-01 until 2015-10-01

--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -2222,7 +2222,7 @@ cybertron: bnemec!redhat.com, cybertron!users.noreply.github.com
 cychiang: cychiang!users.noreply.github.com, cychiang0823!gmail.com, divya.raaga!gmail.com, jimmy.praet!telenet.be
 	OH!COOL
 cyclinder: cyclinder!users.noreply.github.com
-	daocloud
+	DaoCloud Network Technology Co. Ltd.
 cyclingwithelephants: cyclingwithelephants!users.noreply.github.com
 	Independent until 2018-10-01
 	Camshaft Software Limited from 2018-10-01 until 2019-12-01
@@ -21293,7 +21293,7 @@ gsr-shanks: gsr!redhat.com, gsr-shanks!users.noreply.github.com
 gsserge: gsserge!gmail.com, gsserge!users.noreply.github.com
 	Wercker
 gssjl2008: gssjl2008!users.noreply.github.com
-	daocloud
+	DaoCloud Network Technology Co. Ltd.
 gssxd: gssxd!users.noreply.github.com
 	HP Inc. until 2014-12-01
 	Beijing Teamsun from 2014-12-01 until 2018-04-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -11416,6 +11416,8 @@ jpambrun: jf.pambrun!gmail.com, jpambrun!users.noreply.github.com
 	CRCHUM from 2014-12-01 until 2016-12-01
 	NucleusHealth from 2016-12-01 until 2018-11-01
 	Change Healthcare from 2018-11-01
+jpanda-cn: qi.han!daocloud.io, jpanda-cn!user.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 jpantsjoha: jpantsjoha!users.noreply.github.com
 	Sky UK Limited until 2017-06-01
 	loveholidays from 2017-06-01 until 2019-09-01
@@ -20958,6 +20960,8 @@ liyongxin: liyongxin!users.noreply.github.com, yxli!alauda.io
 	yxli
 liyuan198251: gk.wl!qq.com, li.yuan4!zte.com.cn, liyuan198251!users.noreply.github.com
 	ZTE Corporation
+liyuerich: yue.li!daocloud.io, liyuerich!user.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 liz-acosta: liz-acosta!users.noreply.github.com
 	I-5 Publishing until 2014-11-01
 	Independent from 2014-11-01 until 2015-01-01

--- a/developers_affiliations4.txt
+++ b/developers_affiliations4.txt
@@ -732,7 +732,7 @@ huachaohuang: huachao.huang!gmail.com, huachaohuang!users.noreply.github.com
 	NICE Netherlands B.V. from 2014-05-01 until 2016-06-01
 	PingCAP from 2016-06-01
 huan555: huan555!users.noreply.github.com
-	Daocloud
+	DaoCloud Network Technology Co. Ltd.
 huanen: 1973465479!qq.com, huanen!users.noreply.github.com, xuhuan.lc!inspur.com
 	Inspur Group
 huang-jy: huang-jy!users.noreply.github.com

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -15893,7 +15893,8 @@ pacospace: pacospace!users.noreply.github.com
 	Independent from 2018-12-01 until 2019-02-01
 	Red Hat Inc. from 2019-02-01
 pacoxu: paco.xu!daocloud.io, pacoxu!users.noreply.github.com, roollingstone!gmail.com
-	DaoCloud Network Technology Co. Ltd.
+	Dell EMC until 2016-04-18
+	DaoCloud Network Technology Co. Ltd. from 2016-04-18
 paddatrapper: paddatrapper!users.noreply.github.com
 	Western Province Hockey until 2018-09-01
 	AIMS South Africa from 2018-09-01 until 2019-01-01

--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -16123,7 +16123,7 @@ panktishah26: panktishah26!users.noreply.github.com
 	AWS from 2021-04-01
 panpan0000: panpan0000!msn.com, panpan0000!users.noreply.github.com
 	Dell EMC until 2018-07-01
-	DaoCloud.i from 2018-07-01
+	DaoCloud Network Technology Co. Ltd. from 2018-07-01
 panslava: slavik!google.com
 	Independent until 2019-02-01
 	YANDEX LLC from 2019-02-01 until 2019-06-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -16311,6 +16311,8 @@ tangle329: at28997146!163.com, tangle3!wanda.cn, tangle329!users.noreply.github.
 	NetEase Inc
 tangmengqiu: tangmengqiu!users.noreply.github.com
 	ZJU
+tangming1996: ming.tang!daocloud.io, tangming1996!users.noreply.github.com
+	DaoCloud Network Technology Co. Ltd.
 tangrs: dt.tangr!gmail.com, tangrs!tangrs.id.au
 	Independent until 2016-04-01
 	GradReady from 2016-04-01 until 2016-11-01


### PR DESCRIPTION
daocloud、Daocloud.i、 Daocloud are same as DaoCloud Network Technology Co. Ltd.

- [x] @cyclinder
- [x] @gssjl2008
- [x] @ErikJiang
- [x] @Carlory @carlory
- [x] @FangtingYan
- [x] @Frapschen
- [x] @JiaweiGithub
- [x] @Zhuzhenghao
- [x] @alexzhc
- [x] @cyclinder
- [x] @huan555
- [x] @panpan0000
- [x] @pacoxu 

The second commit adds the below users.
- [x] @dapengJacky
- [x] @Rei1010
- [x] @liyuerich
- [x] @jpanda-cn
- [x] @falser101
- [x] @Penguin-zlh
- [x] @cl2017
- [x] @tangming1996
- [x] @Onion-of-dreamed
- [x] @donghui12