### PR TITLE
Remove affiliation with Sportradar

### DIFF
--- a/developers_affiliations5.txt
+++ b/developers_affiliations5.txt
@@ -15784,9 +15784,9 @@ oleksiys: kvrico!gmail.com, oleksiys!google.com, oleksiys!users.noreply.github.c
 	Google LLC
 olekzabl: olekz!google.com, olekzabl!users.noreply.github.com
 	Google LLC
-olemarkus: dmitrii.malakhov!gmail.com, git!o-o.se, o.with!sportradar.com, olemarkus!gmail.com, olemarkus!users.noreply.github.com
+olemarkus: o.with!sportradar.com, olemarkus!gmail.com, olemarkus!users.noreply.github.com
 	Sky LabsAS until 2014-12-01
-	Sportradar from 2014-12-01
+	Sportradar from 2014-12-01 until 2023-01-01
 olemmela: oskari!lemmela.net
 	Elisa Corporation
 olerem: bug-track!fisher-privat.net, fixed-term.oleksij.rempel!de.bosch.com, linux!rempel-privat.de, o.rempel!pengutronix.de


### PR DESCRIPTION
Also remove some email addresses not associated with olemarkus.

Signed-off-by: Ole Markus With <olemarkus@gmail.com>