### PR TITLE
Adding Dynatrace LLC to the domain map

### DIFF
--- a/src/cncf-config/domain-map
+++ b/src/cncf-config/domain-map
@@ -198,6 +198,7 @@ devicescape.com Devicescape
 digi.com Digi International
 digitalpacific.com.au Digital Pacific
 digiware.nl Digiware
+dynatrace.com Dynatrace LLC
 dmm.com DMM.com Labo
 docker.com Docker
 dotcloud.com dotCloud


### PR DESCRIPTION
As I understood, this should improve the automatic mapping of our
employees to the Dynatrace organization, as they're using
their company email. If not, please let me know if there is a way
to achieve this.

Thank you

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>