### PR TITLE
Fix: Somehow my current affiliation got mangled

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -17783,7 +17783,8 @@ bleggett: benjamin.leggett!solo.io, bleggett!jackhenry.com, bleggett!users.norep
 	ProfitStars until 2016-06-01
 	Strategic Systems from 2016-06-01 until 2017-10-01
 	T-Mobile PCS Holdings LLC from 2017-10-01 until 2020-08-01
-	Virtru from 2020-08-01
+	Virtru from 2020-08-01 until 2023-01-15
+	Solo.io from 2023-01-16
 blelump: blelump!users.noreply.github.com
 	Independent
 blencoff: blencoff!users.noreply.github.com


### PR DESCRIPTION
Despite the fact that I set my current affiliation in this PR: https://github.com/cncf/gitdm/pull/1339/files

that current affiliation got mangled + dropped at some point.

Fixing it back. @lukaszgryglicki any ideas what happened? Something I did?

Looks like it was removed [here](https://github.com/cncf/gitdm/commit/6e0ae32de101fa0da8e597afbf00e108cf045f11#diff-7d2b44a5a6a72f383483b011a9c2c4fbbd2fc98d63b97adab082d415f114ec27R17573), I wonder if the fact I had an overlapping date range for 2 of the affiliations caused this.