### PR TITLE
Update Flant users

### DIFF
--- a/developers_affiliations2.txt
+++ b/developers_affiliations2.txt
@@ -699,7 +699,7 @@ ZhaoQiang-b45475: qiang.zhao!nxp.com
 	NXP Semiconductors Netherlands B.V.
 ZhaoxingMeng: meng.zhaoxing1!zte.com.cn
 	ZTE Corporation
-Zhbert: zhbert!yandex.ru
+Zhbert: zhbert!yandex.ru, konstantin.nezhbert!flant.com
 	АО НИИЭФА until 2016-11-01
 	ООО НИИЭФА-ЭНЕРГО from 2016-11-01 until 2019-10-01
 	ООО ПО ЭЛЕРОН from 2019-10-01 until 2020-08-01
@@ -6299,8 +6299,9 @@ alexey-boyko: alexey-boyko!users.noreply.github.com
 	Société Générale from 2019-07-01
 alexey-gavrilov-flant: alexey-gavrilov-flant!users.noreply.github.com, alexey.gavrilov!flant.com
 	FLANT EUROPE OÜ
-alexey-igrychev: alexey-igrychev!users.noreply.github.com, alexey.igrychev!flant.com, driftarp!gmail.com
-	FLANT EUROPE OÜ
+alexey-igrychev: aleksei.igrychev!palark.com, alexey-igrychev!users.noreply.github.com, alexey.igrychev!flant.com, driftarp!gmail.com
+	FLANT EUROPE OÜ until 2022-10-01
+	Palark from 2022-10-01
 alexey-mr: alexey-mr!users.noreply.github.com, alexey.morlang!gmail.com
 	Acronis Inc. until 2015-09-01
 	EMC from 2015-09-01

--- a/developers_affiliations6.txt
+++ b/developers_affiliations6.txt
@@ -13140,8 +13140,9 @@ shurkaxaa: shurkaxaa!users.noreply.github.com
 	Independent until 2016-08-01
 	Brillio from 2016-08-01 until 2018-04-01
 	Tekion from 2018-04-01
-shurup: dmitry.shurupov!flant.com, dmitry.shurupov!flant.ru, shurup!users.noreply.github.com
-	FLANT EUROPE OÜ
+shurup: dmitry.shurupov!palark.com, dmitry.shurupov!flant.com, dmitry.shurupov!flant.ru, shurup!users.noreply.github.com
+	FLANT EUROPE OÜ until 2022-10-01
+	Palark from 2022-10-01
 shuuji3: shuuji3!gmail.com
 	Independent until 2015-07-01
 	Infomatrix from 2015-07-01 until 2016-03-01

--- a/developers_affiliations7.txt
+++ b/developers_affiliations7.txt
@@ -2962,6 +2962,9 @@ valdisk: valdis.kletnieks!vt.edu
 valdisrigdon: valdis.rigdon!appian.com, valdisrigdon!users.noreply.github.com
 	Content until 2014-06-01
 	Appian Corporation Inc. from 2014-06-01
+valent-x: valent-ex!users.noreply.github.com, anton.klimov!flant.com, anton.klimov!palark.com
+	FLANT EUROPE OÜ until 2022-10-01
+	Palark from 2022-10-01
 valentin-krasontovitsch: v.krasontov!gmail.com, valentin-krasontovitsch!users.noreply.github.com
 	Kubernetes
 valentin2105: valentin!ouvrard.it, valentin2105!users.noreply.github.com


### PR DESCRIPTION
A few Flant employees are updated to reflect where they are today.

Last time, I failed to change `src/github_users.json` on my own, so I'd like to ask you to make these related to the PR changes as well, please:

1. Add this to `alexey-igrychev`:
```
    "location": "Portugal",
    "country_id": "pt"
```
2. Add this to `valent-ex`:
```
    "location": "Ulm, Germany",
    "country_id": "de"
```

Sorry for mixing it up in our PR, but it still seems quite reasonable.