### PR TITLE
update DaoCloud developers' information 

### DIFF
--- a/company_developers1.txt
+++ b/company_developers1.txt
@@ -2357,7 +2357,6 @@ AWS:
 	bstascavage: brian!stascavage.com, bstascavage!users.noreply.github.com from 2021-09-01
 	burnechr: burnechr!users.noreply.github.com from 2021-02-01
 	cajual: cajual!users.noreply.github.com from 2020-10-01 until 2021-09-01
-	calvin0327: calvin0327!users.noreply.github.com from 2018-03-01 until 2018-08-01
 	camba1: camba1!users.noreply.github.com from 2021-05-01
 	cancecen: cecen.ycan!gmail.com until 2019-06-01
 	ceisenach: ceisenach!users.noreply.github.com from 2020-01-01
@@ -6190,7 +6189,6 @@ Amazon:
 	bytefire: okash.khawaja!gmail.com from 2014-08-01 until 2015-08-01
 	caesar-chen: caesar-chen!users.noreply.github.com, shizchen!microsoft.com, shizhe95!gmail.com from 2019-02-01
 	cal-pratt: cal-pratt!users.noreply.github.com, cpratt!mun.ca from 2017-07-01 until 2018-10-01
-	calvin0327: calvin0327!users.noreply.github.com from 2017-04-01 until 2017-08-01
 	campionfellin: campionfellin!users.noreply.github.com from 2018-06-01
 	carlosdoordash: carlosdoordash!users.noreply.github.com until 2017-09-01
 	chaochn47: chaochn47!users.noreply.github.com

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -10778,15 +10778,19 @@ DaoCloud Network Technology Co. Ltd.:
 	JaredTan95: JaredTan95!users.noreply.github.com, jian.tan!daocloud.io
 	JiaweiGithub: JiaweiGithub!users.noreply.github.com, jiawei.liu!daocloud.io
 	JoeWrightss: 42261994+joewrightss!users.noreply.github.com, JoeWrightss!users.noreply.github.com, zhoulin.xie!daocloud.io
+	LronDC: LronDC!users.noreply.github.com, lun.su!daocloud.io
 	Michelle951: Michelle951!users.noreply.github.com
+	NiuYinlong1994: NiuYinlong1994!users.noreply.github.com, yinlong.niu!daocloud.io
 	Onion-of-dreamed: Onion-of-dreamed!users.noreply.github.com, chong.yuan!daocloud.io
 	OwenYang1996: OwenYang1996!users.noreply.github.com, dev!ryanwolhuter.com, gaur.var!gmail.com, owen.yang!daocloud.io
 	Penguin-zlh: Penguin-zlh!users.noreply.github.com, lihan.zhou!daocloud.io
+	RachaelLuo: RachaelLuo!users.noreply.github.com
 	Rei1010: 326028565!qq.com, Rei1010!users.noreply.github.com, wen.rui!daocloud.io
 	Revolution1: Revolution1!users.noreply.github.com, revol.cai!daocloud.io
 	SAMZONG: samzong.lu!gmail.com
 	SenXuDC: SenXuDC!users.noreply.github.com, sen.xu!daocloud.io
 	Songjoy: Songjoy!users.noreply.github.com, wenjie.song!daocloud.io
+	SSmallMonster: SSmallMonster!users.noreply.github.com, mingming.zhou!daocloud.io
 	TianTianBigWang: TianTianBigWang!users.noreply.github.com, zilong.wang!daocloud.io
 	WPH95: wph95!users.noreply.github.com from 2015-06-01 until 2015-10-01
 	WillardHu: WillardHu!users.noreply.github.com, wei.hu!daocloud.io
@@ -10797,10 +10801,12 @@ DaoCloud Network Technology Co. Ltd.:
 	allencloud: allen.sun!daocloud.io, allencloud!users.noreply.github.com, allensun.shl!alibaba-inc.com, hi!gunargessner.com, shlallen1990!gmail.com from 2014-12-01 until 2018-09-01
 	anniedy: anniedy!users.noreply.github.com, yu.dong!daocloud.io
 	arugaki: arugaki!users.noreply.github.com, arugaki.wei!daocloud.io
+	bertreyking: bertreyking!users.noreply.github.com, weibing.ma!daocloud.io
 	brooksmtownsend: brooksmtownsend!gmail.com from 2018-08-01 until 2019-03-01
 	chaunceyjiang: chaunceyjiang!gmail.com, chaunceyjiang!users.noreply.github.com, xingyan.jiang!daocloud.io
 	chuanhaojin: chuanhaojin!users.noreply.github.com
 	cl2017: chenlin.liu!daocloud.io, cl2017!users.noreply.github.com, me!liuchenlin.com
+	cleverhu: cleverhu!users.noreply.github.com, shouping.hu!daocloud.io
 	cyclinder: cyclinder!users.noreply.github.com
 	dapengJacky: dapengJacky!users.noreply.github.com, peng.chen!daocloud.io
 	dbdd4us: dbdd4us!users.noreply.github.com, wangtong2712!gmail.com, yunda.wang!daocloud.io
@@ -10822,8 +10828,10 @@ DaoCloud Network Technology Co. Ltd.:
 	jpanda-cn: jpanda-cn!user.noreply.github.com, qi.han!daocloud.io
 	jzhupup: jzhupup!users.noreply.github.com, jzhupup0210!gmail.com
 	kebe7jun: kebe.liu!daocloud.io, kebe7jun!users.noreply.github.com, mail!kebe7jun.com
-	kerthcet: kerthcet!gmail.com
+	kerthcet: kerthcet!gmail.com, kerthcet!user.noreply.github.com, na.yin!daocloud.io
+	learner0810: learner0810!user.noreply.github.com, zhongjun.li!daocloud.io
 	liyuerich: liyuerich!user.noreply.github.com, yue.li!daocloud.io
+	lou-lan: lou-lan!users.noreply.github.com, loulan!loulan.me, huailou.zhai!daocloud.io
 	lrx0014: lrx0014!hotmail.com, lrx0014!users.noreply.github.com, renxiang.li!daocloud.io
 	mengjiao-liu: liumengjiao69!gmail.com, mengjiao.liu!daocloud.io, mengjiao.liu!user.noreply.github.com
 	my-git9: my-git9!users.noreply.github.com, xin.li!daocloud.io
@@ -10841,7 +10849,9 @@ DaoCloud Network Technology Co. Ltd.:
 	vonsago: vonsago!users.noreply.github.com
 	wangkai1994: kai660740!gmail.com, wangkai1994!users.noreply.github.com
 	wawa0210: lzdzel!gmail.com, wawa0210!users.noreply.github.com, xiao.zhang!daocloud.io from 2017-12-01
+	weizhouBlue: weizhouBlue!users.noreply.github.com, weizhou.lan!daocloud.io
 	willnay: ywilling!outlook.com
+	wilsonwu: wilsonwu!users.noreply.github.com, wilson.wu!daocloud.io from 2020-08-21
 	windsonsea: cloudyonspring!126.com
 	wlq1212: 806646991!qq.com, wlq1212!users.noreply.github.com
 	wwwnay: ywilling!outlook.com

--- a/company_developers2.txt
+++ b/company_developers2.txt
@@ -10803,6 +10803,7 @@ DaoCloud Network Technology Co. Ltd.:
 	arugaki: arugaki!users.noreply.github.com, arugaki.wei!daocloud.io
 	bertreyking: bertreyking!users.noreply.github.com, weibing.ma!daocloud.io
 	brooksmtownsend: brooksmtownsend!gmail.com from 2018-08-01 until 2019-03-01
+	calvin0327: calvin0327!users.noreply.github.com, wen.chen!daocloud.io from 2020-08-13
 	chaunceyjiang: chaunceyjiang!gmail.com, chaunceyjiang!users.noreply.github.com, xingyan.jiang!daocloud.io
 	chuanhaojin: chuanhaojin!users.noreply.github.com
 	cl2017: chenlin.liu!daocloud.io, cl2017!users.noreply.github.com, me!liuchenlin.com

--- a/company_developers3.txt
+++ b/company_developers3.txt
@@ -7550,8 +7550,6 @@ Genialis:
 	kostko: jernej!kos.mx from 2015-12-15
 Genie:
 	dray92: debo!uber.com, dray92!uw.edu until 2016-04-01
-Genies:
-	calvin0327: calvin0327!users.noreply.github.com from 2022-04-01
 Genilogic:
 	jdockerty: jdockerty!users.noreply.github.com from 2018-04-01 until 2019-06-01, from 2019-11-01 until 2020-07-01
 Genity:
@@ -15965,7 +15963,6 @@ Houston:
 Houston Pizza Venture:
 	aaronfranke: aaronfranke!users.noreply.github.com, arnfranke!yahoo.com from 2018-03-01 until 2018-07-01
 Houzz:
-	calvin0327: calvin0327!users.noreply.github.com from 2019-02-01 until 2021-07-01
 	saarwasserman: saarwasserman!users.noreply.github.com from 2020-12-01
 	yan-dblinf: yan-dblinf!users.noreply.github.com from 2018-03-01 until 2021-04-01
 Hover:

--- a/company_developers5.txt
+++ b/company_developers5.txt
@@ -4581,7 +4581,6 @@ Independent:
 	calmh: calmh!users.noreply.github.com, jakob!kastelo.net until 2016-09-01
 	calmitchell617: calmitchell617!users.noreply.github.com until 2018-05-01
 	calvin-kargo: calvin-kargo!users.noreply.github.com until 2019-05-01
-	calvin0327: calvin0327!users.noreply.github.com from 2017-08-01 until 2017-10-01, from 2018-08-01 until 2019-02-01
 	camattin: camattin!gmail.com from 2018-01-01 until 2018-09-01
 	camba1: camba1!users.noreply.github.com from 2017-11-01 until 2018-01-01
 	camelpunch: camelpunch!users.noreply.github.com from 2018-03-01 until 2018-07-01

--- a/company_developers5.txt
+++ b/company_developers5.txt
@@ -8867,7 +8867,6 @@ Independent:
 	lostlivio: livio!arleo.net from 2019-11-22
 	lotus-x: lotus-x!users.noreply.github.com
 	lotyrin: greg!dapperbot.com, lotyrin!gmail.com, lotyrin!users.noreply.github.com from 2016-05-01 until 2018-02-01
-	lou-lan: lou-lan!users.noreply.github.com, loulan!loulan.me
 	louis-murray: congfairy2536!gmail.com, louis-murray!users.noreply.github.com, oscar.99.tris!gmail.com, playa1!gmail.com, steffen.butzer!outlook.com until 2015-08-01
 	louisblin: louisblin!users.noreply.github.com from 2015-11-01 until 2016-07-01, from 2016-09-01 until 2017-04-01, from 2017-09-01 until 2018-09-01
 	louisnow: louisnow!users.noreply.github.com until 2016-12-01, from 2018-05-01 until 2018-07-01

--- a/company_developers7.txt
+++ b/company_developers7.txt
@@ -1684,7 +1684,7 @@ Microsoft Corporation:
 	williambernardet: william.bernardet!gmail.com from 2014-04-01
 	willmadison: jpajuelo!conwet.com, willmadison!users.noreply.github.com, wmadisonDev!GMail.com, xwlee2009!gmail.com from 2020-01-01
 	willtsai: willtsai!users.noreply.github.com from 2021-07-01
-	wilsonwu: wilsonwu!users.noreply.github.com
+	wilsonwu: wilsonwu!users.noreply.github.com until 2020-08-21
 	winguse: github!winguse.com, winguse!users.noreply.github.com until 2016-09-01
 	winterTTr: winterTTr!users.noreply.github.com
 	wizcas: wizcas!users.noreply.github.com until 2014-07-01

--- a/company_developers7.txt
+++ b/company_developers7.txt
@@ -4483,7 +4483,6 @@ NVIDIA Corporation:
 	beefyamoeba5: beefyamoeba5!users.noreply.github.com, lvjing5!huawei.com from 2020-10-01
 	bhadram: varkab!cdac.in from 2015-11-01
 	bopiy: dahuang!nvidia.com
-	calvin0327: calvin0327!users.noreply.github.com from 2017-10-01 until 2018-03-01
 	chaitanyav: chaitanyav!users.noreply.github.com until 2015-09-01, from 2018-05-01
 	coffeecup-winner: d.polyanitsa!criteo.com
 	cooloney: cooloney!gmail.com until 2016-07-01
@@ -11034,8 +11033,6 @@ Ory Corp:
 	AlexandreBrg: burgoni!pm.me from 2022-07-01 until 2022-09-01
 Osage Bluff Marina:
 	billf: billf!mu.org, billf!uber.com, billf!users.noreply.github.com, fumerola!gmail.com
-Osaka:
-	calvin0327: calvin0327!users.noreply.github.com until 2017-01-01
 Oscar Health:
 	James-Quigley: James-Quigley!users.noreply.github.com, james!quigley.us, james.a.quigley!asu.edu from 2021-09-01
 	wyattanderson: wanderson!gmail.com from 2014-07-01

--- a/company_developers8.txt
+++ b/company_developers8.txt
@@ -14690,7 +14690,6 @@ Snap Snap:
 	abroglesc: abroglesc!users.noreply.github.com from 2017-03-01
 	aklintsevich: aklintsevich!users.noreply.github.com from 2020-02-01
 	asheldon: asheldon!users.noreply.github.com
-	calvin0327: calvin0327!users.noreply.github.com from 2021-07-01 until 2022-04-01
 	carnott-snap: carnott!snapchat.com, carnott-snap!users.noreply.github.com
 	caseyduquettesc: caseyduquettesc!users.noreply.github.com
 	chiraggadasc: chirag.gada!snapchat.com from 2017-09-01

--- a/company_developers9.txt
+++ b/company_developers9.txt
@@ -7184,8 +7184,6 @@ Thycotic:
 	sheldonhull: sheldonhull!users.noreply.github.com from 2021-03-01
 TiKV:
 	hicqu: hicqu!users.noreply.github.com, onlyqupeng!gmail.com, qupeng!pingcap.com
-TiRest:
-	calvin0327: calvin0327!users.noreply.github.com from 2017-01-01 until 2017-04-01
 TiVo Brands LLC.:
 	BigPapaChas: BigPapaChas!users.noreply.github.com from 2017-05-01 until 2018-07-01
 	lucasreed: lmr0125!gmail.com, lucasreed!users.noreply.github.com from 2014-06-01 until 2019-07-01


### PR DESCRIPTION
Signed-off-by: Paco Xu <paco.xu@daocloud.io>

follow up of #1313
-  include https://github.com/cncf/gitdm/pull/1315/