### PR TITLE
move fujitatomoya to Sony Group Corporation.

### DIFF
--- a/developers_affiliations3.txt
+++ b/developers_affiliations3.txt
@@ -20640,8 +20640,8 @@ fujin: aj!junglistheavy.industries, fujin!users.noreply.github.com
 	Postmates Inc from 2020-04-01
 fujita: fujita.tomonori!gmail.com, fujita.tomonori!lab.ntt.co.jp
 	NTT Corporation
-fujitatomoya: Tomoya.Fujita!sony.com, fujitatomoya!users.noreply.github.com
-	Sony Marketing Inc.
+fujitatomoya: Tomoya.Fujita!sony.com, tomoya.fujita825!gmail.com, fujitatomoya!users.noreply.github.com
+	Sony Group Corporation.
 fujiwara: fujiwara!users.noreply.github.com, fujiwara.shunichiro!gmail.com
 	Independent
 fukuta-tatsuya-intec: fukuta-tatsuya-intec!users.noreply.github.com


### PR DESCRIPTION
I have never belonged to `Sony Marketing Inc`, this PR address that with correct affiliation.

related PR: https://github.com/cncf/gitdm/commit/7d954a5714f5d5eb58399ede8d05ba05ceabc2d5